### PR TITLE
Support for $LANG environment variable

### DIFF
--- a/Aura/Flags.hs
+++ b/Aura/Flags.hs
@@ -201,7 +201,7 @@ fishOutFlag ((f,r):fs) alt flags | f `elem` flags = r
                                  | otherwise      = fishOutFlag fs alt flags
 
 getLanguage :: [Flag] -> Language
-getLanguage = fishOutFlag flagsAndResults english
+getLanguage = fishOutFlag flagsAndResults notSpecified
     where flagsAndResults = zip langFlags langFuns
           langFlags       = [ JapOut,PolishOut,CroatianOut,SwedishOut
                             , GermanOut,SpanishOut,PortuOut,FrenchOut

--- a/Aura/Languages.hs
+++ b/Aura/Languages.hs
@@ -41,7 +41,8 @@ import Aura.Colour.Text (cyan, green, red, blue, yellow)
 
 ---
 
-data Language = English
+data Language = NotSpecified
+              | English
               | Japanese
               | Polish
               | Croatian
@@ -105,6 +106,9 @@ translatorMsg lang = title : names
 allLanguages :: [Language]
 allLanguages = [English ..]
 
+notSpecified :: Language
+notSpecified = NotSpecified
+
 english :: Language
 english = English
 
@@ -148,6 +152,22 @@ bt cs = "`" ++ cyan cs ++ "`"
 whitespace :: Language -> Char
 whitespace Japanese = '　'  -- \12288
 whitespace _ = ' '          -- \32
+
+getLanguageFromEnvironment :: String -> Language
+getLanguageFromEnvironment "C"          = english
+getLanguageFromEnvironment ('e':'n':xs) = english
+getLanguageFromEnvironment ('j':'a':xs) = japanese
+getLanguageFromEnvironment ('p':'l':xs) = polish
+getLanguageFromEnvironment ('h':'r':xs) = croatian
+getLanguageFromEnvironment ('s':'v':xs) = swedish
+getLanguageFromEnvironment ('d':'e':xs) = german
+getLanguageFromEnvironment ('e':'s':xs) = spanish
+getLanguageFromEnvironment ('p':'t':xs) = portuguese
+getLanguageFromEnvironment ('f':'r':xs) = french
+getLanguageFromEnvironment ('r':'u':xs) = russian
+getLanguageFromEnvironment ('i':'t':xs) = italian
+getLanguageFromEnvironment ('s':'r':xs) = serbian
+getLanguageFromEnvironment _            = english
 
 --------------------
 -- AuraLib functions

--- a/Aura/Settings/Enable.hs
+++ b/Aura/Settings/Enable.hs
@@ -25,7 +25,7 @@ module Aura.Settings.Enable
 
 import System.Environment (getEnvironment)
 
-import Aura.Languages (Language)
+import Aura.Languages (Language( NotSpecified ), getLanguageFromEnvironment)
 import Aura.MakePkg   (makepkgConfFile)
 import Aura.Colour.PacmanColorConf
 import Aura.Settings.BadPackages
@@ -48,7 +48,7 @@ getSettings lang (auraFlags,input,pacOpts) = do
                   , pacOptsOf       = pacOpts
                   , otherOpsOf      = map show auraFlags
                   , environmentOf   = environment
-                  , langOf          = lang
+                  , langOf          = checkLang lang environment
                   , pacmanCmdOf     = pmanCommand
                   , editorOf        = getEditor environment
                   , carchOf         = singleEntry makepkgConf "CARCH"
@@ -101,3 +101,8 @@ debugOutput ss = do
                                               pcMagenta ss "MAGENTA" ++
                                               pcCyan ss "CYAN"       ++
                                               pcWhite ss "WHITE" ]
+
+checkLang :: Language -> Environment -> Language
+checkLang NotSpecified env = getLanguageFromEnvironment $ getLangVar env
+checkLang lang         _   = lang
+

--- a/Shell.hs
+++ b/Shell.hs
@@ -174,3 +174,7 @@ getTrueUser env | isTrueRoot env  = "root"
 
 getEditor :: Environment -> String
 getEditor env = fromMaybe "vi" $ getEnvVar "EDITOR" env
+
+-- This will get the LANG variable from the environment
+getLangVar :: Environment -> String
+getLangVar env = fromMaybe "C" $ getEnvVar "LANG" env


### PR DESCRIPTION
I added the support for reading $LANG environment variable to determine which language should be used. Of course, if --language argument is given, it will be used instead of the $LANG variable.

For translators the most important function is getLanguageFromEnvironment in Aura/Languages.hs. It defines currently supported languages (ie. language codes) and fall backs to English if neither the command line argument is supplied nor there is a $LANG environment variable. It uses pattern matching (serbian is matched with ('s':'r':xs) for example) which might be dificult for non-haskellers, but that was the most straight forward solution to xx_YY@zzz.www style language codes with most parts being optional.
