### PR TITLE
Fix "--allsource" flag.

### DIFF
--- a/Aura/MakePkg.hs
+++ b/Aura/MakePkg.hs
@@ -62,7 +62,7 @@ makepkgGen f user =
 
 determineRunStyle :: String -> [String] -> (String,[String])
 determineRunStyle "root" opts = (makepkgCmd,["--asroot"] ++ opts)
-determineRunStyle user opts = ("su",[user,"-c",makepkgCmd ++ intercalate " " opts])
+determineRunStyle user opts = ("su",[user,"-c",makepkgCmd ++ " " ++ intercalate " " opts])
 
 makepkgQuiet :: String -> Aura [FilePath]
 makepkgQuiet user = makepkgGen quiet user


### PR DESCRIPTION
The replacement of "makepkg " with makepkgCmd missed the trailing
space, and hence the flags were being appended to the command instead.

This would in theory cause all flags passed to makepkg to fail, not
just the source ones.
