### PR TITLE
Where there is no package description, show a blank line.

### DIFF
--- a/Aura/Commands/M.hs
+++ b/Aura/Commands/M.hs
@@ -154,4 +154,4 @@ renderSearch pat pkg = repo ++ "/" ++ n ++ " " ++ v ++ " \n    " ++ d
           ns   = namespaceOf pkg
           n    = c bForeground $ pkgNameOf pkg
           v    = green $ trueVersion ns
-          d    = head $ value ns "pkgdesc"
+          d    = concat $ value ns "pkgdesc"


### PR DESCRIPTION
This is the correct behaviour where a package description
isn't supplied, and it fixes (a) cause of issue #104, although
there are others. However, it can also serve to hide
the situation with split packages, which are going to be a bigger
headache in themselves!
