### PR TITLE
Check whether a package is installed before syncing it.

### DIFF
--- a/Aura/Commands/M.hs
+++ b/Aura/Commands/M.hs
@@ -55,6 +55,7 @@ module Aura.Commands.M
 
 import System.Directory (removeDirectoryRecursive, createDirectory)
 import Text.Regex.PCRE  ((=~))
+import Control.Monad ((>=>))
 import Data.Maybe       (catMaybes)
 
 import qualified Aura.Install as I
@@ -89,7 +90,7 @@ defaultHandle pacOpts =
 manualHandle :: [String] -> BuildHandle
 manualHandle _ = BH { pkgLabel = "ABS"
                     , initialPF = filterABSPkgs
-                    , mainPF    = filterABSPkgs
+                    , mainPF    = filterABSPkgs >=> filterInstalledPkgs
                     , subPF     = \_  -> return []
                     , subBuild  = \_  -> return () }
 

--- a/Aura/Packages/ABS.hs
+++ b/Aura/Packages/ABS.hs
@@ -66,6 +66,7 @@ import qualified Shell      as Sh (quietShellCmd)
 ---------------
 -- ABS Packages
 ---------------
+-- | ABSPkg name repository version pkgbuild parsed_pkgbuild
 data ABSPkg = ABSPkg String String VersionDemand Pkgbuild Namespace
 
 instance Package ABSPkg where

--- a/Aura/Packages/Repository.hs
+++ b/Aura/Packages/Repository.hs
@@ -61,6 +61,22 @@ filterRepoPkgs pkgs = do
           specs (c:cs) | c `elem` "+" = ['[',c,']'] ++ specs cs
                        | otherwise    = c : specs cs
 
+{- Get only those packages that are not already installed
+  This is, sadly, a bit of a hack. The reason we do this is that
+  otherwise ABS installs using --absdeps tend to fail when they reach
+  a split/virtual package and cannot sync it. By filtering already
+  installed packages the user can circumvemt this problem.
+-}
+filterInstalledPkgs :: PkgFilter
+filterInstalledPkgs pkgs = do
+  repoPkgs <- lines `fmap` pacmanOutput ["-Qsq",pkgs']
+  return $ filter (`notElem` repoPkgs) pkgs
+    where pkgs' = "^(" ++ prep pkgs ++ ")$"
+          prep  = specs . intercalate "|"
+          specs []     = []
+          specs (c:cs) | c `elem` "+" = ['[',c,']'] ++ specs cs
+                       | otherwise    = c : specs cs
+
 ignoreRepos :: PkgFilter
 ignoreRepos _ = return []
 


### PR DESCRIPTION
This patch changes the behaviour of -M under the --absdeps option.

This fix partially addresses issue #125 by changing the behaviour
described in issue #122, and only syncing packages which are not
already installed.

This applies only to dependencies of a given package, and not when
a package is specified as the main package. This allows packages to be
reinstalled when required explicitly.
