### PR TITLE
Parse empty or single brace expansions

### DIFF
--- a/Bash/Parser.hs
+++ b/Bash/Parser.hs
@@ -115,7 +115,6 @@ unQuoted = map NoQuote <$> extrapolated []
 -- Example: sandwiches-are-{beautiful,fine}
 -- Note that strings like: empty-{}  or  lamp-{shade}
 -- will not be expanded and will retain their braces.
--- BUG: The statement immediately above this is a lie.
 extrapolated :: [Char] -> Parser [String]
 extrapolated stops = do
   xs <- plain <|> bracePair
@@ -125,7 +124,10 @@ extrapolated stops = do
 
 bracePair :: Parser [String]
 bracePair = between (char '{') (char '}') innards <?> "valid {...} string"
-    where innards = concat `fmap` (extrapolated ",}" `sepBy` char ',')
+    where innards = concatInnards <$> (extrapolated ",}" `sepBy` char ',')
+          concatInnards []   = ["{}"]
+          concatInnards [xs] = map (\s -> "{" ++ s ++ "}") xs
+          concatInnards xss  = concat xss
 
 ------------------
 -- `IF` STATEMENTS


### PR DESCRIPTION
Strings like empty-{} or lamp-{shade} will not be expanded and will retain their braces.
