### PR TITLE
Handle `--absdeps` correctly

### DIFF
--- a/Aura/Commands/A.hs
+++ b/Aura/Commands/A.hs
@@ -39,6 +39,7 @@ import qualified Aura.Install as I
 
 import Aura.Packages.Repository
 import Aura.Settings.Base
+import Aura.Packages.ABS (absDepsRepo)
 import Aura.Packages.AUR
 import Aura.Colour.Text
 import Aura.Monad.Aura
@@ -51,15 +52,19 @@ import Utilities (whenM)
 
 ---
 
-installOptions :: I.InstallOptions
-installOptions = I.InstallOptions
-    { label         = "AUR"
-    , installLookup = aurLookup
-    , repository    = pacmanRepo <> aurRepo
-    }
+installOptions :: Aura I.InstallOptions
+installOptions = do
+    depsRepo <- absDepsRepo
+    return I.InstallOptions
+        { label         = "AUR"
+        , installLookup = aurLookup
+        , repository    = depsRepo <> pacmanRepo <> aurRepo
+        }
 
 install :: [String] -> [String] -> Aura ()
-install = I.install installOptions
+install pacOpts ps = do
+    opts <- installOptions
+    I.install opts pacOpts ps
 
 upgradeAURPkgs :: [String] -> [String] -> Aura ()
 upgradeAURPkgs pacOpts pkgs = ask >>= \ss -> do
@@ -136,7 +141,9 @@ renderSearch ss r i = searchResult
             | otherwise     = green $ latestVerOf i
 
 displayPkgDeps :: [String] -> Aura ()
-displayPkgDeps = I.displayPkgDeps installOptions
+displayPkgDeps ps = do
+    opts <- installOptions
+    I.displayPkgDeps opts ps
 
 downloadTarballs :: [String] -> Aura ()
 downloadTarballs pkgs = do

--- a/Aura/Commands/M.hs
+++ b/Aura/Commands/M.hs
@@ -76,15 +76,12 @@ import Utilities (whenM)
 ---
 
 installOptions :: Aura InstallOptions
-installOptions = asks buildABSDeps >>= \manual -> do
-    tree <- absTree
-    let repo = if manual
-               then absRepo tree <> pacmanRepo
-               else pacmanRepo
+installOptions = do
+    depsRepo <- absDepsRepo
     return InstallOptions
         { label         = "ABS"
-        , installLookup = absLookup tree
-        , repository    = repo
+        , installLookup = absLookup
+        , repository    = depsRepo <> pacmanRepo
         }
 
 install :: [String] -> [String] -> Aura ()

--- a/Aura/Languages.hs
+++ b/Aura/Languages.hs
@@ -330,7 +330,7 @@ getRealPkgConflicts_2 p Serbian    = "Пакет " ++ bt p ++ " је игнор�
 
 -- NEEDS TRANSLATION
 missingPkg_1 :: String -> Language -> String
-missingPkg_1 p _ = "The dependency " ++ bt p ++ "could not be found. You may need to search for a package to satisfy it."
+missingPkg_1 p _ = "The dependency " ++ bt p ++ " could not be found. You may need to search for a package to satisfy it."
 
 -----------------
 -- aura functions

--- a/Aura/Packages/AUR.hs
+++ b/Aura/Packages/AUR.hs
@@ -58,7 +58,7 @@ aurLookup name = do
     Traversable.mapM (makeBuildable name) pkgbuild
 
 aurRepo :: Repository
-aurRepo = buildableRepository aurLookup
+aurRepo = Repository $ \name -> fmap packageBuildable <$> aurLookup name
 
 makeBuildable :: String -> Pkgbuild -> Aura Buildable
 makeBuildable name pkgbuild = do

--- a/Aura/Pkgbuild/Base.hs
+++ b/Aura/Pkgbuild/Base.hs
@@ -23,7 +23,6 @@ module Aura.Pkgbuild.Base where
 
 import Aura.Bash
 import Aura.Core
-import Aura.Monad.Aura
 
 ---
 
@@ -55,7 +54,3 @@ packageBuildable b = Package
     }
   where
     ns = namespaceOf b
-
-buildableRepository :: (String -> Aura (Maybe Buildable)) -> Repository
-buildableRepository f = Repository $ \name ->
-    fmap packageBuildable <$> f name


### PR DESCRIPTION
Fixes #122.

For -A and -M commands, --absdeps now tries to sync and build targets
and dependencies that are not already installed. These ABS queries are
done using pacman instead of precomputing the ABS tree. Split packages
are still not handled, but are passed to pacman instead of failing.

Problems this does not fix:
- Split packages (issue #125)
- `-(A|M)d --absdeps` without `sudo` can be misleading, since all ABS syncs fail and the dependencies are passed to pacman instead of being built
- `-A[d] --absdeps` lists all AUR and ABS packages as AUR packages. `label` needs to be moved out of `InstallOptions` and into `Buildable`
