### PR TITLE
Check if deps are installed before resolving

### DIFF
--- a/Aura/Commands/A.hs
+++ b/Aura/Commands/A.hs
@@ -37,7 +37,6 @@ import Data.Monoid
 import           Aura.Install (InstallOptions(..))
 import qualified Aura.Install as I
 
-import Aura.Packages.Repository
 import Aura.Settings.Base
 import Aura.Packages.ABS (absDepsRepo)
 import Aura.Packages.AUR
@@ -58,7 +57,7 @@ installOptions = do
     return I.InstallOptions
         { label         = "AUR"
         , installLookup = aurLookup
-        , repository    = depsRepo <> pacmanRepo <> aurRepo
+        , repository    = depsRepo <> aurRepo
         }
 
 install :: [String] -> [String] -> Aura ()

--- a/Aura/Commands/M.hs
+++ b/Aura/Commands/M.hs
@@ -57,14 +57,12 @@ import System.Directory (removeDirectoryRecursive, createDirectory)
 import Text.Regex.PCRE  ((=~))
 import Control.Monad
 import Data.Maybe       (catMaybes)
-import Data.Monoid
 
 import           Aura.Install (InstallOptions(..))
 import qualified Aura.Install as I
 
 import Aura.Settings.Base
 import Aura.Packages.ABS
-import Aura.Packages.Repository
 import Aura.Colour.Text
 import Aura.Monad.Aura
 import Aura.Languages
@@ -81,7 +79,7 @@ installOptions = do
     return InstallOptions
         { label         = "ABS"
         , installLookup = absLookup
-        , repository    = depsRepo <> pacmanRepo
+        , repository    = depsRepo
         }
 
 install :: [String] -> [String] -> Aura ()

--- a/Aura/Core.hs
+++ b/Aura/Core.hs
@@ -160,10 +160,9 @@ removePkgs [] _         = return ()
 removePkgs pkgs pacOpts = pacman  $ ["-Rsu"] ++ pkgs ++ pacOpts
 
 -- Moving to a libalpm backend will make this less hacked.
--- | Returns if a package needs to be installed. If a package isn't installed,
--- `pacman -T` will yield a single name.
-depTest :: String -> Aura Bool
-depTest s = notNull <$> pacmanOutput ["-T", s]
+-- | Returns if a dependency is satisfied by an installed package.
+depTest :: Dep -> Aura Bool
+depTest (Dep name ver) = null <$> pacmanOutput ["-T", name ++ show ver]
 
 -- | Block further action until the database is free.
 checkDBLock :: Aura ()

--- a/Aura/Dependencies.hs
+++ b/Aura/Dependencies.hs
@@ -47,18 +47,17 @@ resolveDeps repo ps =
         modify $ Map.insert (pkgName pkg) pkg
 
     addDep dep = do
-        mpkg <- getPkg name
+        mpkg <- getPkg $ depName dep
         case mpkg of
-            Nothing  -> findPkg name
+            Nothing  -> findPkg dep
             Just pkg -> lift $ checkConflicts pkg dep
-      where
-        name = depName dep
 
-    findPkg name = do
+    findPkg dep = whenM (not <$> lift (depTest dep)) $ do
         mpkg <- lift $ lookupPkg repo name
         case mpkg of
             Nothing  -> lift $ missingPkg name
-            Just pkg -> addPkg pkg
+            Just pkg -> lift (checkConflicts pkg dep) >> addPkg pkg
+      where name = depName dep
 
     getPkg p = gets $ Map.lookup p
 

--- a/Aura/Packages/ABS.hs
+++ b/Aura/Packages/ABS.hs
@@ -42,7 +42,6 @@ module Aura.Packages.ABS
 
 import           Control.Monad
 import           Data.List          (find)
-import           Data.Monoid
 import           Data.Set           (Set)
 import qualified Data.Set           as Set
 import qualified Data.Traversable   as Traversable
@@ -54,6 +53,7 @@ import           Aura.Bash
 import           Aura.Core
 import           Aura.Languages
 import           Aura.Monad.Aura
+import           Aura.Packages.Repository (pacmanRepo)
 import           Aura.Pacman        (pacmanOutput)
 import           Aura.Pkgbuild.Base
 import           Aura.Settings.Base
@@ -75,17 +75,12 @@ absLookup name = syncRepo name >>= maybe (return Nothing) makeSynced
                 then Just <$> makeBuildable repo name
                 else return Nothing  -- split package, probably
 
--- Already installed packages are not built.
 absRepo :: Repository
-absRepo = Repository $ \name -> do
-    installed <- isInstalled name
-    if installed
-        then return Nothing
-        else fmap packageBuildable <$> absLookup name
+absRepo = Repository $ \name -> fmap packageBuildable <$> absLookup name
 
 absDepsRepo :: Aura Repository
 absDepsRepo = asks (getRepo . buildABSDeps)
-  where getRepo manual = if manual then absRepo else mempty
+  where getRepo manual = if manual then absRepo else pacmanRepo
 
 makeBuildable :: String -> String -> Aura Buildable
 makeBuildable repo name = do


### PR DESCRIPTION
Makes dependency checking slightly faster because it eliminates some
costly package lookups. Simplifies logic for --absdeps and installing.
