### PR TITLE
Overwrite PKGBUILDs when edited

### DIFF
--- a/Aura/Build.hs
+++ b/Aura/Build.hs
@@ -94,9 +94,8 @@ getSourceCode pkg user currDir = liftIO $ do
   cd sourceDir
 
 overwritePkgbuild :: Buildable -> Aura ()
-overwritePkgbuild p = asks mayHotEdit >>= check
-    where check True  = liftIO . writeFile "PKGBUILD" . pkgbuildOf $ p
-          check False = return ()
+overwritePkgbuild p = when (isEdited p) $
+    liftIO . writeFile "PKGBUILD" . pkgbuildOf $ p
 
 -- Inform the user that building failed. Ask them if they want to
 -- continue installing previous packages that built successfully.

--- a/Aura/Core.hs
+++ b/Aura/Core.hs
@@ -79,6 +79,7 @@ data Buildable = Buildable
     , pkgbuildOf :: Pkgbuild
     -- | Did the user select this package, or is it being built as a dep?
     , isExplicit :: Bool
+    , isEdited   :: Bool
     -- | Fetch and extract the source code corresponding to the given package.
     , source     :: FilePath     -- ^ Directory in which to extract the package.
                  -> IO FilePath  -- ^ Path to the extracted source.

--- a/Aura/Packages/ABS.hs
+++ b/Aura/Packages/ABS.hs
@@ -90,6 +90,7 @@ makeBuildable repo name = do
         { baseNameOf = name
         , pkgbuildOf = pb
         , isExplicit = False
+        , isEdited   = False
         , source     = copyTo repo name }
 
 copyTo :: String -> String -> FilePath -> IO FilePath

--- a/Aura/Packages/AUR.hs
+++ b/Aura/Packages/AUR.hs
@@ -63,6 +63,7 @@ makeBuildable name pb = Buildable
     { baseNameOf = name
     , pkgbuildOf = pb
     , isExplicit = False
+    , isEdited   = False
     , source     = \fp -> sourceTarball fp name >>= decompress }
 
 isAurPackage :: String -> Aura Bool

--- a/Aura/Pkgbuild/Editing.hs
+++ b/Aura/Pkgbuild/Editing.hs
@@ -48,7 +48,7 @@ edit f p = do
              writeFile filename $ pkgbuildOf p
              f filename
              readFileUTF8 filename
-  return p { pkgbuildOf = newPB }
+  return p { pkgbuildOf = newPB, isEdited = True }
       where filename = "PKGBUILD"
 
 -- | Allow the user to edit the PKGBUILD if they asked to do so.


### PR DESCRIPTION
Add an `isEdited` flag to `Buildable` to indicate that the PKGBUILD has
changed and should be overwritten during building. Previously, this was
only done when the user used `--hotedit`. Fixes #149.
