### PR TITLE
Added installation verification to AUR search

### DIFF
--- a/Aura/Commands/A.hs
+++ b/Aura/Commands/A.hs
@@ -33,6 +33,7 @@ module Aura.Commands.A
 import Text.Regex.PCRE ((=~))
 import Control.Monad
 import Data.Monoid
+import qualified Data.Set as Set (member, fromList)
 
 import           Aura.Install (InstallOptions(..))
 import qualified Aura.Install as I
@@ -122,8 +123,8 @@ renderAurPkgInfo ss info = entrify ss fields entries
 aurSearch :: [String] -> Aura ()
 aurSearch []    = return ()
 aurSearch regex = ask >>= \ss -> do
-    db       <- getForeignPackages >>= return . map fst
-    results  <- aurSearchLookup regex >>= return . map (\x -> let n = nameOf x in (x, n `elem` db))
+    db       <- getForeignPackages >>= return . Set.fromList . map fst
+    results  <- aurSearchLookup regex >>= return . map (\x -> let n = nameOf x in (x, n `Set.member` db))
     mapM_ (renderSearch ss (unwords regex)) results
 
 renderSearch :: Settings -> String -> (PkgInfo, Bool) -> Aura ()


### PR DESCRIPTION
Hello, I noticed that both pacman and yaourt have markers to indicate whether or not packages listed in the search results (i.e. pacman -Ss, yaourt -Ss) are installed in the user's system (i.e. package name / version/ votes/ "[installed]"). As much as I love your work with my favorite AUR helper, I noticed that your program does not have this simple, -- yet convenient feature. I have made some changes to implement that feature with no reduction in search time/performance. I tried as much as possible to stay in your system, but alas -- I had to change the type signature of one of your functions, as it made it easier for me to implement the change. I hope it is not a drastic change, and thanks for your great work on Aura!! Excellent program, and best of what is available in my opinion.

p.s. I also noticed that some users may have large package lists, which would create a lot of overhead, so I implemented an intermediate Set data structure for O(log n) member operations. Should not make performance difference for small user systems, but should help for very large package databases.

example output:
aur/smlnj 110.76-1 (67) [installed]
    Standard ML of New Jersey, a compiler for the Standard ML '97 programming language
