### PR TITLE
Avoid grouping the backslash as a single

### DIFF
--- a/Bash/Parser.hs
+++ b/Bash/Parser.hs
@@ -83,7 +83,7 @@ variable = Variable <$> name <*> (array <|> single) <?> "valid var definition"
 array :: Parser [BashString]
 array = concat . catMaybes <$> array' <?> "valid array"
     where array'  = char '(' *> spaces *> manyTill single' (char ')')
-          single' = (Nothing <$ comment <* spaces) <|> (Just <$> single)
+          single' = (Nothing <$ comment <* spaces) <|> (Just <$> single <* many (space <|> char '\\'))
 
 -- | Strings can be surrounded by single quotes, double quotes, backticks,
 -- or nothing.


### PR DESCRIPTION
Not sure if this is how you would like to handle this.

The only way I could figure to test this is to hotedit a package and add the backslash after one of the values in the array.
