### PR TITLE
Handle empty lines in arrays with backslash. Fixes #171.

### DIFF
--- a/Bash/Parser.hs
+++ b/Bash/Parser.hs
@@ -83,9 +83,9 @@ variable = Variable <$> name <*> (array <|> single) <?> "valid var definition"
 array :: Parser [BashString]
 array = concat . catMaybes <$> array' <?> "valid array"
     where array'  = char '(' *> spaces *> manyTill single' (char ')')
-          single' =   Nothing <$ comment <* spaces
-                  <|> Nothing <$ many1 (space <|> char '\\')
-                  <|> Just <$> single <* many (space <|> char '\\')
+          single' = choice [ Nothing <$ comment <* spaces
+                           , Nothing <$ many1 (space <|> char '\\')
+                           , Just <$> single <* many (space <|> char '\\') ]
 
 -- | Strings can be surrounded by single quotes, double quotes, backticks,
 -- or nothing.


### PR DESCRIPTION
This was assuming that each line had to either be a `comment` or a `single`. So I just threw in the option for the line to be empty with a backslash.
