### PR TITLE
allow number parameter for --head and --tail

### DIFF
--- a/Aura/Commands/A.hs
+++ b/Aura/Commands/A.hs
@@ -137,8 +137,8 @@ aurSearch regex = ask >>= \ss -> do
     db      <- S.fromList . map fst <$> foreignPackages
     let t = case truncationOf ss of  -- Can't this go anywhere else?
               None -> id
-              Head -> take 10
-              Tail -> reverse . take 10 . reverse
+              Head n -> take n
+              Tail n -> reverse . take n . reverse
     results <- map (\x -> (x, nameOf x `S.member` db)) . t <$> aurSearchLookup regex
     mapM_ (liftIO . putStrLn . renderSearch ss (unwords regex)) results
 

--- a/Aura/Settings/Base.hs
+++ b/Aura/Settings/Base.hs
@@ -31,7 +31,7 @@ import Shell (Environment)
 
 data SortScheme = ByVote | Alphabetically deriving (Eq,Show)
 
-data Truncation = None | Head | Tail deriving (Eq,Show)
+data Truncation = None | Head Int | Tail Int deriving (Eq,Show)
 
 -- The global settings as set by the user with command-line flags.
 data Settings = Settings { inputOf         :: [String]

--- a/aura.8
+++ b/aura.8
@@ -115,11 +115,11 @@ dependencies will only show uncoloured package names.
 Search the AUR via words only (no regex). Results are sorted by vote. 
 Suboptions:
 .RS 4
-\fI\-\-abc\fR  : Sorts results alphabetically.
+\fI\-\-abc\fR    : Sorts results alphabetically.
 .P
-\fI\-\-head\fR : Only show the first 10 results.
+\fI\-\-head\=n\fR : Only show the first n results. Default n = 10
 .P
-\fI\-\-tail\fR : Only show the last 10 results.
+\fI\-\-tail\=n\fR : Only show the last n results.  Default n = 10
 .RE
 .RE
 .P


### PR DESCRIPTION
Hey! I love aura and hope this is a welcome contribution!

This allows one to specify a specific number of items to include in the `--head` and `--tail` options to the search command. This change is backwards-compatible in that the number parameter is optional. If the flag is called in the same way as it was before this change, the number is still assumed to be 10.

In other words, the following continues to work, showing the first 10 results:

```
$ aura -As --head needle
```

The following now works as well, showing the first 3 results:

```
$ aura -As --head=3 needle
```

The reason I made this was because the default value of 10 always scrolled the result I was interested in past my terminal height, since usually what I'm looking for is one of the first if not the first result.

It's working nicely :)
