### PR TITLE
Fix the _aura completions file

### DIFF
--- a/completions/_aura
+++ b/completions/_aura
@@ -241,7 +241,7 @@ _aura() {
         '-w[Download an AUR package source tarball.]'
         '-x[Unsuppress makepkg output during building.]'
         '--aurignore=[Ignore AUR packages when installing.]'
-        '--dryrun[Perform checks, but don't build.]'
+        "--dryrun[Perform checks, but don't build.]"
         '--hotedit[Prompt user to edit PKGBUILD before dep checks.]'
         '--ignorearch[makepkg will ignore processor architecture.]'
     )


### PR DESCRIPTION
A stray ' in don't was messing with strings ;)

i.e. completions are completely and utterly dead for zsh atm.
