### PR TITLE
repo ignores cabal sandboxes now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 *.hi
 *.o
+.cabal-sandbox
+cabal.sandbox.config


### PR DESCRIPTION
I just added a couple of lines to the .gitignore file. I'm working on some other things, but thought this would be cleaner as a separate pull request as it has nothing to do with the other stuff I'm working on.
