### PR TITLE
Added a check for builduser to trueRoot. Fixes #245

### DIFF
--- a/Aura/Core.hs
+++ b/Aura/Core.hs
@@ -128,9 +128,10 @@ sudo action = do
 -- | Prompt if the user is the true Root. Building as it can be dangerous.
 trueRoot :: Aura () -> Aura ()
 trueRoot action = ask >>= \ss ->
-  if isntTrueRoot $ environmentOf ss then action else do
-       okay <- optionalPrompt trueRoot_1
-       if okay then action else notify trueRoot_2
+  if isntTrueRoot (environmentOf ss) || buildUserOf ss /= "root"
+    then action else do
+      okay <- optionalPrompt trueRoot_1
+      if okay then action else notify trueRoot_2
 
 -- `-Qm` yields a list of sorted values.
 foreignPackages :: Aura [(String,String)]


### PR DESCRIPTION
I did some limited testing of this, namely:
- log in as root and issue `aura -A winetricks-git` and `aura -A --builduser=aspidites winetricks-git`
- repeat as normal user using `sudo` and `su`

It's rather early for me, so I'm not sure if I missed the existence of an actual test suite. I'd also appreciate feedback on coding style, as the conventions used in aura are somewhat different than what I've used, so I suspect that while the indentation that I used for the if expression is valid, it's not entirely in keeping with aura's overall style. 
