### PR TITLE
GHC 8.8

### DIFF
--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -8,8 +8,8 @@ module Main ( main ) where
 import           Aura.Pkgbuild.Fetch (getPkgbuild)
 import           Aura.Pkgbuild.Security (bannedTerms, parsedPB)
 import           Aura.Types
+import           Aura.Utils (fmapEither)
 import           BasePrelude
-import           Control.Compactable (fmapEither)
 import           Control.Concurrent.Async (mapConcurrently)
 import           Control.Error.Util (note)
 import           Data.List.Split (chunksOf)

--- a/aur-security/aur-security.cabal
+++ b/aur-security/aur-security.cabal
@@ -23,7 +23,6 @@ executable aur-security
     , aura
     , base             >=4.8 && <5
     , base-prelude     >=1.2 && <1.4
-    , compactable      >=0.1 && <0.2
     , errors           >=2.3 && <2.4
     , http-client      >=0.5 && <0.7
     , http-client-tls  >=0.3 && <0.4

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -48,7 +48,7 @@ common libexec
     , errors                       ^>=2.3
     , http-client                  >=0.5 && <0.7
     , nonempty-containers          ^>=0.3
-    , prettyprinter                >=1.2 && <1.6
+    , prettyprinter                >=1.2 && <1.7
     , prettyprinter-ansi-terminal  ^>=1.1
     , transformers                 ^>=0.5
     , typed-process                ^>=0.2
@@ -89,14 +89,13 @@ library
   build-depends:
     , aeson             >=1.2  && <1.5
     , aeson-pretty      ^>=0.8
-    , algebraic-graphs  >=0.1  && <0.5
+    , algebraic-graphs  >=0.1  && <0.6
     , aur               ^>=6.3
-    , compactable       ^>=0.1
     , filepath          ^>=1.4
     , generic-lens      >=1.1  && <1.3
     , http-types        >=0.9  && <0.13
     , language-bash     ^>=0.8
-    , megaparsec        ^>=7
+    , megaparsec        >=7    && <9
     , microlens-ghc     ^>=0.4
     , mwc-random        ^>=0.14
     , network-uri       ^>=2.6

--- a/aura/exec/Flags.hs
+++ b/aura/exec/Flags.hs
@@ -11,13 +11,13 @@ import           Aura.Cache (defaultPackageCache)
 import           Aura.Pacman (defaultLogFile, pacmanConfFile)
 import           Aura.Settings
 import           Aura.Types
-import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
-import           Lens.Micro
+import           Lens.Micro (Traversal')
 import           Options.Applicative
 import           RIO hiding (exp, log)
 import           RIO.List.Partial (foldr1)
+import qualified RIO.NonEmpty.Partial as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 import           System.Path (Absolute, Path, fromAbsoluteFilePath, toFilePath)

--- a/aura/exec/Settings.hs
+++ b/aura/exec/Settings.hs
@@ -27,7 +27,6 @@ import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils
 import           Control.Error.Util (failWith)
-import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except
 import           Data.Bifunctor (Bifunctor(..))
 import qualified Data.Set.NonEmpty as NES

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -25,16 +25,14 @@ import           Aura.Pacman (pacman)
 import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils
-import           Control.Compactable (traverseMaybe)
-import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except
 import           Data.Generics.Product (field)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Semigroup.Foldable (fold1)
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import           RIO
 import           RIO.Directory (setCurrentDirectory)
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 import           System.Path

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -39,7 +39,6 @@ import           Aura.Utils
 import           Control.Error.Util (hush)
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.Generics.Product (field)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import           Data.Text.Prettyprint.Doc
@@ -51,8 +50,9 @@ import           Network.HTTP.Client (Manager)
 import           RIO
 import qualified RIO.ByteString as B
 import qualified RIO.ByteString.Lazy as BL
-import           RIO.List (intersperse)
+import qualified RIO.List as L
 import           RIO.List.Partial (maximum)
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 import           RIO.Text.Partial (splitOn)
@@ -158,7 +158,7 @@ renderSearch ss r (i, e) = searchResult
           verboseInfo  = repo <> n <+> v <+> "(" <> l <+> "|" <+> p <>
                          ")" <> (if e then annotate bold " [installed]" else "") <> "\n    " <> d
           repo = magenta "aur/"
-          n = fold . intersperse (bCyan $ pretty r) . map (annotate bold . pretty) . splitOn r $ aurNameOf i
+          n = fold . L.intersperse (bCyan $ pretty r) . map (annotate bold . pretty) . splitOn r $ aurNameOf i
           d = maybe "(null)" pretty $ aurDescriptionOf i
           l = yellow . pretty $ aurVotesOf i  -- `l` for likes?
           p = yellow . pretty . T.pack . printf "%0.2f" $ popularityOf i

--- a/aura/lib/Aura/Commands/B.hs
+++ b/aura/lib/Aura/Commands/B.hs
@@ -24,9 +24,9 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.State
 import           Aura.Utils (optionalPrompt, putTextLn)
-import qualified Data.List.NonEmpty as NEL
 import           RIO
-import           RIO.List (partition)
+import qualified RIO.List as L
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Text as T
 import           System.Path (takeFileName, toFilePath, toUnrootedFilePath)
 import           System.Path.IO (removeFile)
@@ -37,7 +37,7 @@ import           System.Path.IO (removeFile)
 cleanStates :: Settings -> Word -> IO ()
 cleanStates ss (fromIntegral -> n) = do
   stfs <- reverse <$> getStateFiles
-  (pinned, others) <- partition p <$> traverse (\sf -> (sf,) <$> readState sf) stfs
+  (pinned, others) <- L.partition p <$> traverse (\sf -> (sf,) <$> readState sf) stfs
   warn ss . cleanStates_4 (length stfs) $ langOf ss
   unless (null pinned) . warn ss . cleanStates_6 (length pinned) $ langOf ss
   forM_ (NEL.nonEmpty stfs) $ \stfs' -> do

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -25,12 +25,11 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types (PkgName(..))
 import           Aura.Utils
-import           Control.Compactable (fmapEither)
 import           Data.Generics.Product (field)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NESet)
 import           Data.Text.Prettyprint.Doc
 import           RIO hiding (FilePath)
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Text as T
 import qualified RIO.Text.Partial as T
 import           System.Path (toFilePath)

--- a/aura/lib/Aura/Core.hs
+++ b/aura/lib/Aura/Core.hs
@@ -39,21 +39,18 @@ import           Aura.Pkgbuild.Editing (hotEdit)
 import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils
-import           Control.Compactable (fmapEither)
 import           Control.Monad.Trans.Maybe
 import           Data.Bifunctor (bimap)
 import           Data.Generics.Product (field)
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           Data.These (These(..))
-import           Lens.Micro ((^.))
 import           RIO hiding ((<>))
 import qualified RIO.ByteString as B
-import           RIO.List (unzip)
+import qualified RIO.List as L
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 import           System.Path.IO (doesFileExist)
@@ -94,7 +91,7 @@ instance Semigroup Repository where
 -- there is no way to guarantee that the list of `NESet`s will itself be
 -- non-empty.
 partitionPkgs :: NonEmpty (NESet Package) -> ([Prebuilt], [NESet Buildable])
-partitionPkgs = bimap fold f . unzip . map g . toList
+partitionPkgs = bimap fold f . L.unzip . map g . toList
   where g = fmapEither toEither . toList
         f = mapMaybe (fmap NES.fromList . NEL.nonEmpty)
         toEither (FromAUR b)  = Right b

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -31,8 +31,6 @@ import           Aura.Types
 import           Aura.Utils (maybe', putText)
 import           Control.Error.Util (note)
 import           Data.Generics.Product (field)
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Semigroup.Foldable (foldMap1)
 import           Data.Set.NonEmpty (pattern IsEmpty, pattern IsNonEmpty, NESet)
 import qualified Data.Set.NonEmpty as NES
@@ -41,6 +39,7 @@ import           Data.Versions
 import           Lens.Micro
 import           RIO
 import qualified RIO.Map as M
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -39,12 +39,11 @@ import           Aura.Colour
 import qualified Aura.Languages.Fields as Fields
 import           Aura.Types
 import           Data.Generics.Product (field)
-import           Data.List.NonEmpty (NonEmpty)
 import           Data.Ratio ((%))
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           RIO
-import           RIO.List (intersperse)
+import qualified RIO.List as L
 import qualified RIO.Map as M
 import qualified RIO.Map.Partial as M
 import qualified RIO.Text as T
@@ -369,7 +368,7 @@ missingPkg_4 :: [NonEmpty PkgName] -> Language -> Doc AnsiStyle
 missingPkg_4 pns = \case
   Spanish    -> vsep $ "Se detectaron los siguientes ciclos de dependencia:" : pns'
   _ -> vsep $ "The following dependency cycles were detected:" : pns'
-  where pns' = map (hsep . map pretty . intersperse "=>" . map (view (field @"name")) . toList) pns
+  where pns' = map (hsep . map pretty . L.intersperse "=>" . map (view (field @"name")) . toList) pns
 
 -----------------
 -- aura functions

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -20,12 +20,12 @@ import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils (optionalPrompt)
 import           Control.Error.Util (note)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import           Lens.Micro (_2)
 import           RIO
 import qualified RIO.ByteString.Lazy as BL
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Text as T
 import           System.Path
     (Absolute, Path, fromAbsoluteFilePath, toFilePath, (</>))

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -32,15 +32,11 @@ import           Aura.Languages
 import           Aura.Pkgbuild.Fetch
 import           Aura.Settings
 import           Aura.Types
-import           Control.Compactable (fmapEither)
-import           Control.Concurrent.STM.TVar (modifyTVar')
+import           Aura.Utils (fmapEither)
 import           Control.Error.Util (hush, note)
-import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Maybe
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NEL
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import           Data.Versions (versioning)
@@ -48,8 +44,9 @@ import           Lens.Micro (each, non, (^..))
 import           Linux.Arch.Aur
 import           Network.HTTP.Client (Manager)
 import           RIO
-import           RIO.List (sortBy)
+import qualified RIO.List as L
 import qualified RIO.Map as M
+import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 import           System.Path
@@ -140,7 +137,7 @@ clone b = do
 -- RPC CALLS
 ------------
 sortAurInfo :: Maybe BuildSwitch -> [AurInfo] -> [AurInfo]
-sortAurInfo bs ai = sortBy compare' ai
+sortAurInfo bs ai = L.sortBy compare' ai
   where compare' = case bs of
                      Just SortAlphabetically -> compare `on` aurNameOf
                      _ -> \x y -> compare (aurVotesOf y) (aurVotesOf x)

--- a/aura/lib/Aura/Packages/Repository.hs
+++ b/aura/lib/Aura/Packages/Repository.hs
@@ -22,12 +22,10 @@ import           Aura.Languages (provides_1)
 import           Aura.Pacman (pacmanLines, pacmanOutput)
 import           Aura.Settings (CommonSwitch(..), Settings(..), shared)
 import           Aura.Types
-import           Aura.Utils (getSelection)
-import           Control.Compactable (fmapEither, traverseEither)
+import           Aura.Utils (fmapEither, getSelection, traverseEither)
 import           Control.Error.Util (hush, note)
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)
-import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Set.NonEmpty as NES
 import           Data.Versions
 import           RIO hiding (try)

--- a/aura/lib/Aura/Utils.hs
+++ b/aura/lib/Aura/Utils.hs
@@ -32,6 +32,9 @@ module Aura.Utils
   , getSelection
     -- * Misc.
   , maybe'
+  , fmapEither
+  , traverseMaybe
+  , traverseEither
   ) where
 
 import           Aura.Colour
@@ -228,3 +231,23 @@ padding ss fs = map (T.justifyLeft longest ws) fs
 -- | `maybe` with the function at the end.
 maybe' :: b -> Maybe a -> (a -> b) -> b
 maybe' zero m f = maybe zero f m
+
+-- | Borrowed from Compactable.
+fmapEither :: (a -> Either b c) -> [a] -> ([b], [c])
+fmapEither f = foldl' (deal f) ([],[])
+  where
+    deal :: (a -> Either b c) -> ([b], [c]) -> a -> ([b], [c])
+    deal g ~(bs, cs) a = case g a of
+      Left b  -> (b:bs, cs)
+      Right c -> (bs, c:cs)
+
+-- | Borrowed from Compactable.
+traverseMaybe :: Applicative f => (a -> f (Maybe b)) -> [a] -> f [b]
+traverseMaybe f = go
+  where
+    go (x:xs) = maybe id (:) <$> f x <*> go xs
+    go []     = pure []
+
+-- | Borrowed from Compactable.
+traverseEither :: Applicative f => (a -> f (Either b c)) -> [a] -> f ([b], [c])
+traverseEither f = fmap partitionEithers . traverse f

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.27
+resolver: lts-15.0
 
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
@@ -15,6 +15,5 @@ packages:
   - aur-security/
 
 extra-deps:
-  - compactable-0.1.2.3
   - language-bash-0.8.0
   - paths-0.2.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: compactable-0.1.2.3@sha256:1dccae8bcf6aa4cfd01e2fd0ec36c98d6efdd3247b6ab1a49a7cfdede4d27d95,1707
-    pantry-tree:
-      size: 275
-      sha256: ffbb73c57e16e3cf2d943a47bed42dd949648fca934715bcd1a3fb93b715edcf
-  original:
-    hackage: compactable-0.1.2.3
-- completed:
     hackage: language-bash-0.8.0@sha256:2a7b0498c029f0e7c30d3b273897e32036a629ff9ffa5c92ec2f3a51f46af86f,1620
     pantry-tree:
       size: 1006
@@ -27,7 +20,7 @@ packages:
     hackage: paths-0.2.0.0
 snapshots:
 - completed:
-    size: 524996
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
-    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
-  original: lts-14.27
+    size: 488576
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/0.yaml
+    sha256: e4b6a87b47ec1cf63a7f1a0884a3b276fce2b0d174a10e8753c4f618e7983568
+  original: lts-15.0


### PR DESCRIPTION
This bumps the Stackage resolver to `lts-15`, which is based on GHC 8.8.2. The future is now!

GHC 8.8 has better Redundant Import detection, so we ended up losing lines overall in this PR.