### PR TITLE
Put Aura on a Diet

### DIFF
--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -8,10 +8,9 @@ module Main ( main ) where
 import           Aura.Pkgbuild.Fetch (getPkgbuild)
 import           Aura.Pkgbuild.Security (bannedTerms, parsedPB)
 import           Aura.Types
-import           Aura.Utils (fmapEither)
+import           Aura.Utils
 import           BasePrelude
 import           Control.Concurrent.Async (mapConcurrently)
-import           Control.Error.Util (note)
 import           Data.List.Split (chunksOf)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T

--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TupleSections     #-}
 
 module Main ( main ) where
 

--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -17,7 +17,6 @@ import qualified Data.Text.IO as T
 import           Language.Bash.Pretty (prettyText)
 import           Network.HTTP.Client (newManager)
 import           Network.HTTP.Client.TLS (tlsManagerSettings)
-import           Text.Pretty.Simple (pPrintNoColor)
 
 ---
 
@@ -38,7 +37,7 @@ main = do
   let !bads = mapMaybe g parsed
   unless (null bads) $ do
     putStrLn $ printf "%d PKGBUILDs contained banned bash terms. They were:" (length bads)
-    traverse_ pPrintNoColor bads
+    traverse_ print bads
   putStrLn "Done."
     where f pair@(pn, _) = note pn $ traverse parsedPB pair
           g = traverse (maybeList . map (first prettyText) . bannedTerms)

--- a/aur-security/Main.hs
+++ b/aur-security/Main.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE BangPatterns      #-}
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE TupleSections #-}
 
 module Main ( main ) where
 
@@ -8,14 +7,20 @@ import           Aura.Pkgbuild.Fetch (getPkgbuild)
 import           Aura.Pkgbuild.Security (bannedTerms, parsedPB)
 import           Aura.Types
 import           Aura.Utils
-import           BasePrelude
 import           Control.Concurrent.Async (mapConcurrently)
+import           Control.Monad (unless)
+import           Data.Bifunctor (first)
+import           Data.Either (partitionEithers)
+import           Data.Foldable (fold, traverse_)
+import           Data.List (sort)
 import           Data.List.Split (chunksOf)
+import           Data.Maybe (mapMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import           Language.Bash.Pretty (prettyText)
 import           Network.HTTP.Client (newManager)
 import           Network.HTTP.Client.TLS (tlsManagerSettings)
+import           Text.Printf (printf)
 
 ---
 

--- a/aur-security/aur-security.cabal
+++ b/aur-security/aur-security.cabal
@@ -26,6 +26,5 @@ executable aur-security
     , http-client      >=0.5 && <0.7
     , http-client-tls  >=0.3 && <0.4
     , language-bash    >=0.8 && <0.10
-    , pretty-simple    >=2.1 && <3.3
     , split            >=0.2 && <0.3
     , text

--- a/aur-security/aur-security.cabal
+++ b/aur-security/aur-security.cabal
@@ -22,7 +22,6 @@ executable aur-security
       async
     , aura
     , base             >=4.8 && <5
-    , base-prelude     >=1.2 && <1.4
     , http-client      >=0.5 && <0.7
     , http-client-tls  >=0.3 && <0.4
     , language-bash    >=0.8 && <0.10

--- a/aur-security/aur-security.cabal
+++ b/aur-security/aur-security.cabal
@@ -23,7 +23,6 @@ executable aur-security
     , aura
     , base             >=4.8 && <5
     , base-prelude     >=1.2 && <1.4
-    , errors           >=2.3 && <2.4
     , http-client      >=0.5 && <0.7
     , http-client-tls  >=0.3 && <0.4
     , language-bash    >=0.8 && <0.10

--- a/aur/CHANGELOG.md
+++ b/aur/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+#### Added
+
+- The `AurError` type to account for the API change described below.
+
+#### Changed
+
+- The `servant` dependency has been dropped in favour of vanilla `http-client`.
+- `info` and `search` now return the custom `AurError` type instead of servant's
+  `ClientError`.
+
+#### Removed
+
+- The reexport of `ClientError` from servant.
+
 ## 6.3.1
 
 - Rewiden `servant` bounds.

--- a/aur/aur.cabal
+++ b/aur/aur.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               aur
-version:            6.3.1
+version:            7.0.0
 synopsis:           Access metadata from the Arch Linux User Repository.
 description:
   Access package information from Arch Linux's AUR via its RPC interface. The
@@ -36,10 +36,9 @@ library
   hs-source-dirs:  lib
   exposed-modules: Linux.Arch.Aur
   build-depends:
-    , aeson           >=0.9  && <1.5
-    , servant         >=0.16 && <0.18
-    , servant-client  >=0.16 && <0.18
-    , text            ^>=1.2
+    , aeson       >=0.9  && <1.5
+    , http-types  ^>=0.12
+    , text        ^>=1.2
 
 test-suite aur-test
   import:         commons

--- a/aur/aur.cabal
+++ b/aur/aur.cabal
@@ -37,6 +37,7 @@ library
   exposed-modules: Linux.Arch.Aur
   build-depends:
     , aeson       >=0.9  && <1.5
+    , bytestring
     , http-types  ^>=0.12
     , text        ^>=1.2
 

--- a/aur/lib/Linux/Arch/Aur.hs
+++ b/aur/lib/Linux/Arch/Aur.hs
@@ -25,7 +25,6 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Network.HTTP.Client
 import           Network.HTTP.Types.Status
-import           Text.Printf (printf)
 
 ---
 
@@ -115,22 +114,8 @@ instance ToJSON AurInfo where
     , "License" .= licenseOf ai
     , "Keywords" .= keywordsOf ai ]
 
----
-
--- type Info = "rpc" :> QueryParam "v" Text
---            :> QueryParam "type" Text
---            :> QueryParams "arg[]" Text
---            :> Get '[JSON] RPCResp
-
--- type Search = "rpc" :> QueryParam "v" Text
---            :> QueryParam "type" Text
---            :> QueryParam "arg" Text
---            :> Get '[JSON] RPCResp
-
 data AurError = NoConnection | BadJSON | OtherAurError
   deriving stock (Eq, Ord, Show)
-
--- TODO What's the problem with the `arg[]` syntax?
 
 -- | Perform an @info@ call on one or more package names.
 -- Will fail with a `Left` if there was a connection/decoding error.
@@ -138,14 +123,14 @@ info :: Manager -> [Text] -> IO (Either AurError [AurInfo])
 info m ps = work m url
   where
     url = "https://aur.archlinux.org/rpc?v=5&type=info&" <> as
-    as = T.unpack . T.intercalate "&" $ map ("arg=" <>) ps
+    as = T.unpack . T.intercalate "&" $ map ("arg%5B%5D=" <>) ps
 
 -- | Perform a @search@ call on a package name or description text.
 -- Will fail with a `Left` if there was a connection/decoding error.
 search :: Manager -> Text -> IO (Either AurError [AurInfo])
 search m p = work m url
   where
-    url = printf "https://aur.archlinux.org/rpc?v=5&type=search&arg=%s" p
+    url = "https://aur.archlinux.org/rpc?v=5&type=search&arg=" <> T.unpack p
 
 work :: Manager -> String -> IO (Either AurError [AurInfo])
 work m url = do

--- a/aur/tests/Test.hs
+++ b/aur/tests/Test.hs
@@ -18,7 +18,7 @@ suite m = testGroup "RPC Calls"
   ]
 
 infoTest :: Manager -> Assertion
-infoTest m = info m ["aura"] >>= \x -> (not . null <$> x) @?= Right True
+infoTest m = info m ["aura", "aura-bin"] >>= \x -> (length <$> x) @?= Right 2
 
 infoTest' :: Manager -> Assertion
 infoTest' m = info m ["aura1234567"] >>= \x -> (null <$> x) @?= Right True

--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Allow `--asdeps` to be passed to `-A` commands.
 - Dutch translations. Thank you, Joris Blanken!
 
+#### Changed
+
+- ~15% reduction in binary size and must faster compiles due to removal of
+  unnecessary dependencies.
+- A few more messages when using `--log-level=debug`.
+
 ## 2.2.1 (2020-03-01)
 
 #### Changed

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -95,7 +95,7 @@ library
     , aeson             >=1.2  && <1.5
     , aeson-pretty      ^>=0.8
     , algebraic-graphs  >=0.1  && <0.6
-    , aur               ^>=6.3
+    , aur               ^>=7.0
     , filepath          ^>=1.4
     , generic-lens      >=1.1  && <1.3
     , http-types        >=0.9  && <0.13
@@ -106,7 +106,6 @@ library
     , network-uri       ^>=2.6
     , scheduler         >=1.1  && <1.5
     , semigroupoids     >=5.2  && <5.4
-    , servant-client-core >= 0.16 && < 0.18
     , stm               ^>=2.5
     , these             ^>=1.0
     , time              >=1.8  && <1.10

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -95,11 +95,11 @@ library
     , aur               ^>=7.0
     , filepath          ^>=1.4
     , generic-lens      >=1.1  && <1.3
+    , hashable          ^>= 1.3
     , http-types        >=0.9  && <0.13
     , language-bash     >=0.8  && <0.10
     , megaparsec        >=7    && <9
     , microlens-ghc     ^>=0.4
-    , mwc-random        ^>=0.14
     , network-uri       ^>=2.6
     , scheduler         >=1.1  && <1.5
     , semigroupoids     >=5.2  && <5.4

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -96,7 +96,6 @@ library
     , http-types        >=0.9  && <0.13
     , language-bash     >=0.8  && <0.10
     , megaparsec        >=7    && <9
-    , microlens-ghc     ^>=0.4
     , network-uri       ^>=2.6
     , scheduler         >=1.1  && <1.5
     , stm               ^>=2.5

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -89,7 +89,6 @@ library
 
   build-depends:
     , aeson             >=1.2  && <1.5
-    , aeson-pretty      ^>=0.8
     , algebraic-graphs  >=0.1  && <0.6
     , aur               ^>=7.0
     , filepath          ^>=1.4

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -47,7 +47,6 @@ common commons
 common libexec
   build-depends:
     , http-client                  >=0.5 && <0.7
-    , nonempty-containers          ^>=0.3
     , prettyprinter                >=1.2 && <1.7
     , prettyprinter-ansi-terminal  ^>=1.1
     , transformers                 ^>=0.5
@@ -102,7 +101,6 @@ library
     , microlens-ghc     ^>=0.4
     , network-uri       ^>=2.6
     , scheduler         >=1.1  && <1.5
-    , semigroupoids     >=5.2  && <5.4
     , stm               ^>=2.5
     , these             ^>=1.0
     , time              >=1.8  && <1.10

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -27,11 +27,7 @@ common commons
   default-language:   Haskell2010
   default-extensions:
     NoImplicitPrelude
-    BangPatterns
-    LambdaCase
     OverloadedStrings
-    TupleSections
-    TypeApplications
 
   ghc-options:
     -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
@@ -87,6 +83,7 @@ library
     Aura.Pkgbuild.Records
     Aura.Pkgbuild.Security
     Aura.Settings
+    Aura.Shell
     Aura.State
     Aura.Types
     Aura.Utils

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -93,7 +93,6 @@ library
     , algebraic-graphs  >=0.1  && <0.6
     , aur               ^>=7.0
     , filepath          ^>=1.4
-    , generic-lens      >=1.1  && <1.3
     , hashable          ^>= 1.3
     , http-types        >=0.9  && <0.13
     , language-bash     >=0.8  && <0.10

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -46,7 +46,6 @@ common commons
 
 common libexec
   build-depends:
-    , errors                       ^>=2.3
     , http-client                  >=0.5 && <0.7
     , nonempty-containers          ^>=0.3
     , prettyprinter                >=1.2 && <1.7

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -70,6 +70,7 @@ library
     Aura.Dependencies
     Aura.Diff
     Aura.Install
+    Aura.IO
     Aura.Languages
     Aura.Languages.Fields
     Aura.Logo

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -122,7 +122,6 @@ executable aura
     , aura
     , http-client-tls       ^>=0.3
     , optparse-applicative  >=0.14 && <0.16
-    , pretty-simple         >=2.1  && <3.3
 
 test-suite aura-test
   import:         commons

--- a/aura/exec/Settings.hs
+++ b/aura/exec/Settings.hs
@@ -31,8 +31,8 @@ import           Aura.Pacman
 import           Aura.Settings
 import           Aura.Shell
 import           Aura.Types
+import           Aura.Utils (nes)
 import           Data.Bifunctor (Bifunctor(..))
-import qualified Data.Set.NonEmpty as NES
 import           Flags
 import           Lens.Micro (folded, (^..), _Right)
 import           Network.HTTP.Client (newManager)
@@ -57,7 +57,7 @@ withEnv (Program op co bc lng ll) f = do
   environment <- M.fromList . map (bimap T.pack T.pack) <$> getEnvironment
   manager     <- newManager tlsManagerSettings
   isTerm      <- hIsTerminalDevice stdout
-  fromGroups  <- maybe (pure S.empty) groupPackages . NES.nonEmptySet
+  fromGroups  <- maybe (pure S.empty) groupPackages . nes
     $ getIgnoredGroups confFile <> igg
   let language = checkLang lng environment
   bu <- maybe (throwM $ Failure whoIsBuildUser_1) pure

--- a/aura/exec/Settings.hs
+++ b/aura/exec/Settings.hs
@@ -79,6 +79,7 @@ withEnv (Program op co bc lng ll) f = do
                  , logPathOf   =
                      first (\x -> fromMaybe x $ getLogFilePath confFile) $ logPathOf co }
           , buildConfigOf = bc { buildUserOf = Just bu}
+          , logLevelOf = ll
           , logFuncOf = logFunc }
     f (Env repos ss)
 

--- a/aura/exec/Settings.hs
+++ b/aura/exec/Settings.hs
@@ -29,8 +29,8 @@ import           Aura.Packages.AUR (aurRepo)
 import           Aura.Packages.Repository (pacmanRepo)
 import           Aura.Pacman
 import           Aura.Settings
+import           Aura.Shell
 import           Aura.Types
-import           Aura.Utils
 import           Data.Bifunctor (Bifunctor(..))
 import qualified Data.Set.NonEmpty as NES
 import           Flags

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -42,12 +42,12 @@ import           Aura.Commands.C as C
 import           Aura.Commands.L as L
 import           Aura.Commands.O as O
 import           Aura.Core
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Logo
 import           Aura.Pacman
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (putTextLn)
 import           Data.Bifunctor (first)
 import qualified Data.Set.NonEmpty as NES
 import           Data.Text.Prettyprint.Doc

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -58,7 +58,6 @@ import           RIO hiding (first)
 import           Settings
 import           System.Path (toFilePath)
 import           System.Process.Typed (proc, runProcess)
-import           Text.Pretty.Simple (pPrintNoColor)
 
 ---
 
@@ -92,10 +91,10 @@ execOpts :: Either (PacmanOp, Set MiscOp) AuraOp -> RIO Env ()
 execOpts ops = do
   logDebug "Interpreting CLI options."
   ss <- asks settings
-  when (shared ss Debug) $ do
-    liftIO . pPrintNoColor $ ops
-    liftIO . pPrintNoColor $ buildConfigOf ss
-    liftIO . pPrintNoColor $ commonConfigOf ss
+  when (logLevelOf ss == LevelDebug) $ do
+    logDebug $ displayShow ops
+    logDebug . displayShow $ buildConfigOf ss
+    logDebug . displayShow $ commonConfigOf ss
   let p (ps, ms) = liftIO . pacman $
         asFlag ps
         ++ foldMap asFlag ms

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -35,29 +35,29 @@ along with Aura.  If not, see <http://www.gnu.org/licenses/>.
 
 module Main ( main ) where
 
-import           Aura.Colour (dtot)
-import           Aura.Commands.A as A
-import           Aura.Commands.B as B
-import           Aura.Commands.C as C
-import           Aura.Commands.L as L
-import           Aura.Commands.O as O
-import           Aura.Core
-import           Aura.IO
-import           Aura.Languages
-import           Aura.Logo
-import           Aura.Pacman
-import           Aura.Settings
-import           Aura.Types
-import           Data.Bifunctor (first)
-import qualified Data.Set.NonEmpty as NES
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Render.Terminal
-import           Flags
-import           Options.Applicative (execParser)
-import           RIO hiding (first)
-import           Settings
-import           System.Path (toFilePath)
-import           System.Process.Typed (proc, runProcess)
+import Aura.Colour (dtot)
+import Aura.Commands.A as A
+import Aura.Commands.B as B
+import Aura.Commands.C as C
+import Aura.Commands.L as L
+import Aura.Commands.O as O
+import Aura.Core
+import Aura.IO
+import Aura.Languages
+import Aura.Logo
+import Aura.Pacman
+import Aura.Settings
+import Aura.Types
+import Aura.Utils (nes)
+import Data.Bifunctor (first)
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Terminal
+import Flags
+import Options.Applicative (execParser)
+import RIO hiding (first)
+import Settings
+import System.Path (toFilePath)
+import System.Process.Typed (proc, runProcess)
 
 ---
 
@@ -135,7 +135,7 @@ execOpts ops = do
     Right (Orphans o) ->
       case o of
         Nothing               -> liftIO O.displayOrphans
-        Just OrphanAbandon    -> sudo $ liftIO orphans >>= traverse_ removePkgs . NES.nonEmptySet
+        Just OrphanAbandon    -> sudo $ liftIO orphans >>= traverse_ removePkgs . nes
         Just (OrphanAdopt ps) -> O.adoptPkg ps
     Right Version   -> liftIO $ versionInfo >>= animateVersionMsg ss auraVersion
     Right Languages -> displayOutputLanguages

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Build
@@ -20,6 +21,7 @@ import           Aura.MakePkg
 import           Aura.Packages.AUR (clone)
 import           Aura.Pacman (pacman)
 import           Aura.Settings
+import           Aura.Shell (chown)
 import           Aura.Types
 import           Aura.Utils
 import           Control.Monad.Trans.Except

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -16,6 +16,7 @@ module Aura.Build
   ) where
 
 import           Aura.Core
+import           Aura.IO
 import           Aura.Languages
 import           Aura.MakePkg
 import           Aura.Packages.AUR (clone)
@@ -23,7 +24,6 @@ import           Aura.Pacman (pacman)
 import           Aura.Settings
 import           Aura.Shell (chown)
 import           Aura.Types
-import           Aura.Utils
 import           Control.Monad.Trans.Except
 import           Data.Generics.Product (field)
 import           Data.Semigroup.Foldable (fold1)

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -92,10 +92,10 @@ build' ss b = do
 randomDirName :: Buildable -> IO (Path Absolute)
 randomDirName b = do
   pwd <- getCurrentDirectory
-  UTCTime (ModifiedJulianDay d) _ <- getCurrentTime
+  UTCTime _ dt <- getCurrentTime
   let nh = hash . pnName $ bName b
       vh = hash $ bVersion b
-      v  = abs $ nh + vh + hash d
+      v  = abs $ nh + vh + floor dt
       dir = T.unpack (pnName $ bName b) <> "-" <> show v
   pure $ pwd </> fromUnrootedFilePath dir
 

--- a/aura/lib/Aura/Cache.hs
+++ b/aura/lib/Aura/Cache.hs
@@ -22,7 +22,6 @@ module Aura.Cache
 
 import           Aura.Settings
 import           Aura.Types
-import           Data.Generics.Product (field)
 import           RIO
 import qualified RIO.Map as M
 import qualified RIO.Set as S
@@ -56,10 +55,10 @@ cacheContents pth = cache . map (PackagePath . (pth </>)) <$> getDirectoryConten
 pkgsInCache :: Settings -> Set PkgName -> IO (Set PkgName)
 pkgsInCache ss ps = do
   c <- cacheContents . either id id . cachePathOf $ commonConfigOf ss
-  pure . S.filter (`S.member` ps) . S.map (^. field @"name") . M.keysSet $ _cache c
+  pure . S.filter (`S.member` ps) . S.map spName . M.keysSet $ _cache c
 
 -- | Any entries (filepaths) in the cache that match a given `Text`.
 cacheMatches :: Settings -> Text -> IO [PackagePath]
 cacheMatches ss input = do
   c <- cacheContents . either id id . cachePathOf $ commonConfigOf ss
-  pure . filter (T.isInfixOf input . T.pack . toFilePath . path) . M.elems $ _cache c
+  pure . filter (T.isInfixOf input . T.pack . toFilePath . ppPath) . M.elems $ _cache c

--- a/aura/lib/Aura/Cache.hs
+++ b/aura/lib/Aura/Cache.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Cache

--- a/aura/lib/Aura/Cache.hs
+++ b/aura/lib/Aura/Cache.hs
@@ -23,8 +23,6 @@ module Aura.Cache
 import           Aura.Settings
 import           Aura.Types
 import           Data.Generics.Product (field)
-import           Data.Set.NonEmpty (NESet)
-import qualified Data.Set.NonEmpty as NES
 import           RIO
 import qualified RIO.Map as M
 import qualified RIO.Set as S
@@ -55,10 +53,10 @@ cacheContents :: Path Absolute -> IO Cache
 cacheContents pth = cache . map (PackagePath . (pth </>)) <$> getDirectoryContents pth
 
 -- | All packages from a given `Set` who have a copy in the cache.
-pkgsInCache :: Settings -> NESet PkgName -> IO (Set PkgName)
+pkgsInCache :: Settings -> Set PkgName -> IO (Set PkgName)
 pkgsInCache ss ps = do
   c <- cacheContents . either id id . cachePathOf $ commonConfigOf ss
-  pure . S.filter (`NES.member` ps) . S.map (^. field @"name") . M.keysSet $ _cache c
+  pure . S.filter (`S.member` ps) . S.map (^. field @"name") . M.keysSet $ _cache c
 
 -- | Any entries (filepaths) in the cache that match a given `Text`.
 cacheMatches :: Settings -> Text -> IO [PackagePath]

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -37,7 +37,6 @@ import           Aura.Settings
 import           Aura.State (saveState)
 import           Aura.Types
 import           Aura.Utils
-import           Control.Error.Util (hush)
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.Generics.Product (field)
 import           Data.Set.NonEmpty (NESet)

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE MultiWayIf       #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns     #-}
 
 -- |
 -- Module    : Aura.Commands.A

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -29,6 +29,7 @@ module Aura.Commands.A
 import           Aura.Colour
 import           Aura.Core
 import qualified Aura.Install as I
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Packages.AUR
 import           Aura.Pkgbuild.Fetch

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -36,7 +36,7 @@ import           Aura.Settings
 import           Aura.State (saveState)
 import           Aura.Types
 import           Aura.Utils
-import           Data.Aeson.Encode.Pretty (encodePretty)
+import           Data.Aeson
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           Data.Versions (Versioning, prettyV, versioning)
@@ -184,7 +184,7 @@ aurJson :: NonEmpty PkgName -> RIO Env ()
 aurJson ps = do
   m <- asks (managerOf . settings)
   infos <- liftMaybeM (Failure connectFailure_1) . fmap hush . liftIO $ f m ps
-  traverse_ (BL.putStrLn . encodePretty) infos
+  traverse_ (BL.putStrLn . encode) infos
   where
     f :: Manager -> NonEmpty PkgName -> IO (Either AurError [AurInfo])
     f m = info m . map pnName . NEL.toList

--- a/aura/lib/Aura/Commands/A.hs
+++ b/aura/lib/Aura/Commands/A.hs
@@ -188,7 +188,7 @@ aurJson ps = do
   infos <- liftMaybeM (Failure connectionFailure_1) . fmap hush . liftIO $ f m ps
   traverse_ (BL.putStrLn . encodePretty) infos
   where
-    f :: Manager -> NESet PkgName -> IO (Either ClientError [AurInfo])
+    f :: Manager -> NESet PkgName -> IO (Either AurError [AurInfo])
     f m = info m . (^.. each . field @"name") . toList
 
 -- | @https://aur.archlinux.org/cgit/aur.git/snapshot/aura-bin.tar.gz@

--- a/aura/lib/Aura/Commands/B.hs
+++ b/aura/lib/Aura/Commands/B.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiWayIf    #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns  #-}
 
 -- |

--- a/aura/lib/Aura/Commands/B.hs
+++ b/aura/lib/Aura/Commands/B.hs
@@ -18,10 +18,10 @@ module Aura.Commands.B
   ) where
 
 import           Aura.Core (warn)
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.State
-import           Aura.Utils (optionalPrompt, putTextLn)
 import           RIO
 import qualified RIO.List as L
 import qualified RIO.NonEmpty as NEL

--- a/aura/lib/Aura/Commands/C.hs
+++ b/aura/lib/Aura/Commands/C.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf       #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Commands.C
@@ -24,6 +26,7 @@ import           Aura.Core
 import           Aura.Languages
 import           Aura.Pacman (pacman)
 import           Aura.Settings
+import           Aura.Shell
 import           Aura.State
 import           Aura.Types
 import           Aura.Utils

--- a/aura/lib/Aura/Commands/C.hs
+++ b/aura/lib/Aura/Commands/C.hs
@@ -23,13 +23,13 @@ module Aura.Commands.C
 import           Aura.Cache
 import           Aura.Colour (red)
 import           Aura.Core
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Pacman (pacman)
 import           Aura.Settings
 import           Aura.Shell
 import           Aura.State
 import           Aura.Types
-import           Aura.Utils
 import           Data.Generics.Product (field)
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE TypeApplications      #-}
 
 -- |
 -- Module    : Aura.Commands.L

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -25,7 +25,6 @@ import           Aura.Settings
 import           Aura.Types (PkgName(..))
 import           Aura.Utils
 import           Data.Generics.Product (field)
-import           Data.Set.NonEmpty (NESet)
 import           Data.Text.Prettyprint.Doc
 import           RIO hiding (FilePath)
 import qualified RIO.NonEmpty as NEL
@@ -59,7 +58,7 @@ searchLogFile ss input = do
   traverse_ putTextLn $ searchLines input logFile
 
 -- | The result of @-Li@.
-logInfoOnPkg :: NESet PkgName -> RIO Env ()
+logInfoOnPkg :: NonEmpty PkgName -> RIO Env ()
 logInfoOnPkg pkgs = do
   ss <- asks settings
   let pth = toFilePath . either id id . logPathOf $ commonConfigOf ss

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -19,6 +19,7 @@ module Aura.Commands.L
 
 import           Aura.Colour (dtot, red)
 import           Aura.Core (Env(..), report)
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types (PkgName(..))

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Commands.L
@@ -24,7 +23,6 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types (PkgName(..))
 import           Aura.Utils
-import           Data.Generics.Product (field)
 import           Data.Text.Prettyprint.Doc
 import           RIO hiding (FilePath)
 import qualified RIO.NonEmpty as NEL
@@ -75,7 +73,7 @@ logLookup (Log lns) p = case matches of
              , firstInstall = T.take 16 $ T.tail h
              , upgrades = fromIntegral . length $ filter (T.isInfixOf " upgraded ") t
              , recent = reverse . take 5 $ reverse t }
-  where matches = filter (T.isInfixOf (" " <> (p ^. field @"name") <> " (")) lns
+  where matches = filter (T.isInfixOf (" " <> pnName p <> " (")) lns
 
 renderEntry :: Settings -> LogEntry -> Text
 renderEntry ss (LogEntry (PkgName pn) fi us rs) =

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -16,7 +16,6 @@ import Aura.IO (putTextLn)
 import Aura.Pacman (pacman)
 import Aura.Types
 import Data.Generics.Product (field)
-import Data.Set.NonEmpty (NESet)
 import RIO
 
 ---
@@ -26,5 +25,5 @@ displayOrphans :: IO ()
 displayOrphans = orphans >>= traverse_ (putTextLn . view (field @"name"))
 
 -- | Identical to @-D --asexplicit@.
-adoptPkg :: NESet PkgName -> RIO Env ()
+adoptPkg :: NonEmpty PkgName -> RIO Env ()
 adoptPkg pkgs = sudo . liftIO . pacman $ ["-D", "--asexplicit"] <> asFlag pkgs

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Commands.O

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -12,9 +12,9 @@
 module Aura.Commands.O ( displayOrphans, adoptPkg ) where
 
 import Aura.Core (Env(..), orphans, sudo)
+import Aura.IO (putTextLn)
 import Aura.Pacman (pacman)
 import Aura.Types
-import Aura.Utils (putTextLn)
 import Data.Generics.Product (field)
 import Data.Set.NonEmpty (NESet)
 import RIO

--- a/aura/lib/Aura/Commands/O.hs
+++ b/aura/lib/Aura/Commands/O.hs
@@ -15,14 +15,13 @@ import Aura.Core (Env(..), orphans, sudo)
 import Aura.IO (putTextLn)
 import Aura.Pacman (pacman)
 import Aura.Types
-import Data.Generics.Product (field)
 import RIO
 
 ---
 
 -- | Print the result of @pacman -Qqdt@
 displayOrphans :: IO ()
-displayOrphans = orphans >>= traverse_ (putTextLn . view (field @"name"))
+displayOrphans = orphans >>= traverse_ (putTextLn . pnName)
 
 -- | Identical to @-D --asexplicit@.
 adoptPkg :: NonEmpty PkgName -> RIO Env ()

--- a/aura/lib/Aura/Core.hs
+++ b/aura/lib/Aura/Core.hs
@@ -31,6 +31,7 @@ module Aura.Core
   ) where
 
 import           Aura.Colour
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Pacman
 import           Aura.Pkgbuild.Editing (hotEdit)

--- a/aura/lib/Aura/Core.hs
+++ b/aura/lib/Aura/Core.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE MultiWayIf         #-}
+{-# LANGUAGE TypeApplications   #-}
 
 -- |
 -- Module    : Aura.Core
@@ -34,6 +35,7 @@ import           Aura.Languages
 import           Aura.Pacman
 import           Aura.Pkgbuild.Editing (hotEdit)
 import           Aura.Settings
+import           Aura.Shell
 import           Aura.Types
 import           Aura.Utils
 import           Control.Monad.Trans.Maybe

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -25,11 +25,8 @@ import           Aura.IO
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (maybe', note)
+import           Aura.Utils
 import           Data.Generics.Product (field)
-import           Data.Semigroup.Foldable (foldMap1)
-import           Data.Set.NonEmpty (pattern IsEmpty, pattern IsNonEmpty, NESet)
-import qualified Data.Set.NonEmpty as NES
 import           Data.These (these)
 import           Data.Versions
 import           Lens.Micro
@@ -52,11 +49,11 @@ data Resolution = Resolution
 -- interdependent, and thus can be built and installed as a group.
 --
 -- Deeper layers of the result list (generally) depend on the previous layers.
-resolveDeps :: Repository -> NESet Package -> RIO Env (NonEmpty (NESet Package))
+resolveDeps :: Repository -> NonEmpty Package -> RIO Env (NonEmpty (NonEmpty Package))
 resolveDeps repo ps = do
   ss <- asks settings
   res <- liftIO $ (Just <$> resolveDeps' ss repo ps) `catchAny` const (pure Nothing)
-  Resolution m s <- maybe (throwM $ Failure connectionFailure_1) pure res
+  Resolution m s <- maybe (throwM $ Failure connectFailure_1) pure res
   unless (length ps == length m) $ liftIO (putText "\n")
   let de = conflicts ss m s
   unless (null de) . throwM . Failure $ missingPkg_2 de
@@ -64,21 +61,21 @@ resolveDeps repo ps = do
 
 -- | Solve dependencies for a set of `Package`s assumed to not be
 -- installed/satisfied.
-resolveDeps' :: Settings -> Repository -> NESet Package -> IO Resolution
+resolveDeps' :: Settings -> Repository -> NonEmpty Package -> IO Resolution
 resolveDeps' ss repo ps = resolve (Resolution mempty mempty) ps
   where
     -- | Only searches for packages that we haven't checked yet.
-    resolve :: Resolution -> NESet Package -> IO Resolution
-    resolve r@(Resolution m _) xs = maybe' (pure r) (NES.nonEmptySet goods) $ \goods' -> do
+    resolve :: Resolution -> NonEmpty Package -> IO Resolution
+    resolve r@(Resolution m _) xs = maybe' (pure r) (NEL.nonEmpty goods) $ \goods' -> do
       let m' = M.fromList (map (pname &&& id) $ toList goods')
           r' = r & field @"toInstall" %~ (<> m')
       these (const $ pure r') (satisfy r') (const $ satisfy r') $ dividePkgs goods'
       where
-        goods :: Set Package
-        goods = NES.filter (\p -> not $ pname p `M.member` m) xs
+        goods :: [Package]
+        goods = NEL.filter (\p -> not $ pname p `M.member` m) xs
 
     -- | All dependencies from all potential `Buildable`s.
-    allDeps :: NESet Buildable -> Set Dep
+    allDeps :: NonEmpty Buildable -> Set Dep
     allDeps = foldMap1 (S.fromList . (^.. field @"deps" . each))
 
     -- | Deps which are not yet queued for install.
@@ -89,26 +86,28 @@ resolveDeps' ss repo ps = resolve (Resolution mempty mempty) ps
         f d = let n = d ^. field @"name" in not $ M.member n m || S.member n s
 
     -- | Consider only "unsatisfied" deps.
-    satisfy :: Resolution -> NESet Buildable -> IO Resolution
-    satisfy r bs = maybe' (pure r) (NES.nonEmptySet . freshDeps r $ allDeps bs) $
+    satisfy :: Resolution -> NonEmpty Buildable -> IO Resolution
+    satisfy r bs = maybe' (pure r) (nes . freshDeps r $ allDeps bs) $
       areSatisfied >=> these (lookups r) (pure . r') (\uns sat -> lookups (r' sat) uns)
       where
         r' :: Satisfied -> Resolution
         r' (Satisfied sat) = r & field @"satisfied" %~ (<> f sat)
 
-        f :: NESet Dep -> Set PkgName
-        f = S.map (^. field @"name") . NES.toSet
+        -- | Unique names of some dependencies.
+        f :: NonEmpty Dep -> Set PkgName
+        f = S.fromList . NEL.toList . NEL.map (^. field @"name")
 
     -- TODO What about if `repoLookup` reports deps that don't exist?
     -- i.e. the left-hand side of the tuple.
     -- | Lookup unsatisfied deps and recurse the entire lookup process.
     lookups :: Resolution -> Unsatisfied -> IO Resolution
     lookups r (Unsatisfied ds) = do
-      let names = NES.map (^. field @"name") ds
+      let names = NEL.map (^. field @"name") ds
       repoLookup repo ss names >>= \case
         Nothing -> throwString "AUR Connection Error"
-        Just (_, IsEmpty) -> throwString "Non-existant deps"
-        Just (_, IsNonEmpty goods) -> resolve r goods
+        Just (_, could) -> case nes could of
+          Nothing    -> throwString "Non-existant deps"
+          Just goods -> resolve r goods
 
 conflicts :: Settings -> Map PkgName Package -> Set PkgName -> [DepError]
 conflicts ss m s = foldMap f m
@@ -127,16 +126,20 @@ conflicts ss m s = foldMap f m
                                 Nothing -> Just $ NonExistant dn
                                 Just p  -> realPkgConflicts ss (b ^. field @"name") p d
 
-sortInstall :: Map PkgName Package -> Either Failure (NonEmpty (NESet Package))
+sortInstall :: Map PkgName Package -> Either Failure (NonEmpty (NonEmpty Package))
 sortInstall m = case cycles depGraph of
-  [] -> note (Failure missingPkg_3) . NEL.nonEmpty . mapMaybe NES.nonEmptySet $ batch depGraph
+  [] -> note (Failure missingPkg_3) . NEL.nonEmpty . mapMaybe nes $ batch depGraph
   cs -> Left . Failure . missingPkg_4 $ map (NEL.map pname . NAM.vertexList1) cs
-  where f (FromRepo _)  = []
-        f p@(FromAUR b) = mapMaybe (\d -> fmap (p,) $ (d ^. field @"name") `M.lookup` m) $ b ^. field @"deps" -- TODO handle "provides"?
-        depGraph  = overlay connected singles
-        elems     = M.elems m
-        connected = edges $ foldMap f elems
-        singles   = overlays $ map vertex elems
+  where
+    f :: Package -> [(Package, Package)]
+    f (FromRepo _)  = []
+    f p@(FromAUR b) = mapMaybe (\d -> fmap (p,) $ (d ^. field @"name") `M.lookup` m)
+      $ b ^. field @"deps" -- TODO handle "provides"?
+
+    depGraph  = overlay connected singles
+    elems     = M.elems m
+    connected = edges $ foldMap f elems
+    singles   = overlays $ map vertex elems
 
 cycles :: Ord a => AdjacencyMap a -> [NAM.AdjacencyMap a]
 cycles = filter (not . isAcyclic) . vertexList . scc

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -21,10 +21,11 @@ import           Algebra.Graph.AdjacencyMap.Algorithm (scc)
 import qualified Algebra.Graph.NonEmpty.AdjacencyMap as NAM
 import           Algebra.Graph.ToGraph (isAcyclic)
 import           Aura.Core
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (maybe', putText)
+import           Aura.Utils (maybe')
 import           Control.Error.Util (note)
 import           Data.Generics.Product (field)
 import           Data.Semigroup.Foldable (foldMap1)

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE PatternSynonyms   #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE MultiWayIf       #-}
+{-# LANGUAGE PatternSynonyms  #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Dependencies

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -25,8 +25,7 @@ import           Aura.IO
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (maybe')
-import           Control.Error.Util (note)
+import           Aura.Utils (maybe', note)
 import           Data.Generics.Product (field)
 import           Data.Semigroup.Foldable (foldMap1)
 import           Data.Set.NonEmpty (pattern IsEmpty, pattern IsNonEmpty, NESet)

--- a/aura/lib/Aura/IO.hs
+++ b/aura/lib/Aura/IO.hs
@@ -1,0 +1,95 @@
+-- |
+-- Module    : Aura.IO
+-- Copyright : (c) Colin Woodbury, 2012 - 2020
+-- License   : GPL3
+-- Maintainer: Colin Woodbury <colin@fosskers.ca>
+--
+-- User-facing input and output utilities.
+
+module Aura.IO where
+
+import           Aura.Colour
+import           Aura.Languages (whitespace, yesNoMessage, yesPattern)
+import           Aura.Settings
+import           Aura.Types (Language)
+import           Data.Text.Prettyprint.Doc
+import           Data.Text.Prettyprint.Doc.Render.Terminal
+import           RIO
+import qualified RIO.ByteString as B
+import qualified RIO.ByteString.Lazy as BL
+import           RIO.List.Partial (maximum)
+import qualified RIO.Text as T
+import           Text.Printf (printf)
+
+---
+
+----------------
+-- CUSTOM OUTPUT
+----------------
+-- | Print a `Doc` with Aura flair after performing a `colourCheck`.
+putStrLnA :: Settings -> Doc AnsiStyle -> IO ()
+putStrLnA ss d = putStrA ss $ d <> hardline
+
+-- | Will remove all colour annotations if the user specified @--color=never@.
+putStrA :: Settings -> Doc AnsiStyle -> IO ()
+putStrA ss d = B.putStr . encodeUtf8 . dtot $ "aura >>=" <+> colourCheck ss d
+
+-- | Strip colours from a `Doc` if @--color=never@ is specified,
+-- or if the output target isn't a terminal.
+colourCheck :: Settings -> Doc ann -> Doc ann
+colourCheck ss | shared ss (Colour Never)  = unAnnotate
+               | shared ss (Colour Always) = id
+               | isTerminal ss = id
+               | otherwise = unAnnotate
+
+putText :: Text -> IO ()
+putText = B.putStr . encodeUtf8
+
+putTextLn :: Text -> IO ()
+putTextLn = BL.putStrLn . BL.fromStrict . encodeUtf8
+
+-- | Format two lists into two nice rows a la `-Qi` or `-Si`.
+entrify :: Settings -> [Text] -> [Doc AnsiStyle] -> Doc AnsiStyle
+entrify ss fs es = vsep $ zipWith combine fs' es
+  where fs' = padding ss fs
+        combine f e = annotate bold (pretty f) <+> ":" <+> e
+
+-- | Right-pads strings according to the longest string in the group.
+padding :: Settings -> [Text] -> [Text]
+padding ss fs = map (T.justifyLeft longest ws) fs
+  where ws      = whitespace $ langOf ss
+        longest = maximum $ map T.length fs
+
+----------
+-- PROMPTS
+----------
+yesNoPrompt :: Settings -> Doc AnsiStyle -> IO Bool
+yesNoPrompt ss msg = do
+  putStrA ss . yellow $ msg <+> yesNoMessage (langOf ss) <> " "
+  hFlush stdout
+  response <- decodeUtf8Lenient <$> B.getLine
+  pure $ isAffirmative (langOf ss) response
+
+-- | An empty response emplies "yes".
+isAffirmative :: Language -> Text -> Bool
+isAffirmative l t = T.null t || elem (T.toCaseFold t) (yesPattern l)
+
+-- | Doesn't prompt when `--noconfirm` is used.
+optionalPrompt :: Settings -> (Language -> Doc AnsiStyle) -> IO Bool
+optionalPrompt ss msg | shared ss NoConfirm = pure True
+                      | otherwise           = yesNoPrompt ss (msg $ langOf ss)
+
+-- | Given a number of selections, allows the user to choose one.
+getSelection :: Foldable f => (a -> Text) -> f a -> IO a
+getSelection f choiceLabels = do
+  let quantity = length choiceLabels
+      valids   = map tshow [1..quantity]
+      pad      = show . length . show $ quantity
+      choices  = zip valids $ toList choiceLabels
+  traverse_ (\(l,v) -> printf ("%" <> pad <> "s. %s\n") l (f v)) choices
+  BL.putStr ">> "
+  hFlush stdout
+  userChoice <- decodeUtf8Lenient <$> B.getLine
+  case userChoice `lookup` choices of
+    Just valid -> pure valid
+    Nothing    -> getSelection f choiceLabels  -- Ask again.

--- a/aura/lib/Aura/Install.hs
+++ b/aura/lib/Aura/Install.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE BangPatterns     #-}
 {-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds   #-}
 {-# LANGUAGE MultiWayIf       #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns     #-}
 
 -- |

--- a/aura/lib/Aura/Install.hs
+++ b/aura/lib/Aura/Install.hs
@@ -26,6 +26,7 @@ import           Aura.Colour
 import           Aura.Core
 import           Aura.Dependencies (resolveDeps)
 import           Aura.Diff (diff)
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Packages.AUR (aurLookup)
 import           Aura.Pacman (pacman, pacmanSuccess)
@@ -34,7 +35,7 @@ import           Aura.Pkgbuild.Records
 import           Aura.Pkgbuild.Security
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (fmapEither, optionalPrompt, putTextLn)
+import           Aura.Utils (fmapEither)
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (HasField'(..), field, super)
 import           Data.Semigroup.Foldable (fold1)

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1252,6 +1252,10 @@ miscAURFailure_2 = \case
   Dutch     -> "De AUR server heeft het verzoek afgewezen."
   _         -> "The AUR server rejected the request."
 
+miscAURFailure_3 :: Language -> Doc AnsiStyle
+miscAURFailure_3 = \case
+  _ -> "The JSON returned from the AUR server could not be decoded."
+
 infoFields :: Language -> [Text]
 infoFields = sequence [ Fields.repository
                       , Fields.name

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1235,8 +1235,8 @@ reportNotInLog_1 = \case
 -------------------------------
 
 -- https://github.com/fosskers/aura/issues/498
-connectionFailure_1 :: Language -> Doc AnsiStyle
-connectionFailure_1 = \case
+connectFailure_1 :: Language -> Doc AnsiStyle
+connectFailure_1 = \case
   Spanish -> "No se pudo contactar con el AUR. ¿Tienes conexión a internet?"
   Italian -> "Non è stato possibile contattare l'AUR. Il computer è connesso ad internet?"
   Dutch   -> "Contact opnemen met de AUR mislukt. Heeft U een internet connectie?"

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns     #-}
 
 {-# OPTIONS_HADDOCK prune #-}
 {-# OPTIONS_GHC -fno-warn-missing-export-lists #-}

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -39,7 +39,6 @@ module Aura.Languages where
 import           Aura.Colour
 import qualified Aura.Languages.Fields as Fields
 import           Aura.Types
-import           Data.Generics.Product (field)
 import           Data.Ratio ((%))
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
@@ -209,7 +208,7 @@ mustBeRoot_1 = let sudo = bt "sudo" in \case
 -- Aura/Build functions
 -----------------------
 buildPackages_1 :: PkgName -> Language -> Doc AnsiStyle
-buildPackages_1 (bt . view (field @"name") -> p) = \case
+buildPackages_1 (bt . pnName -> p) = \case
     Japanese   -> p <> "を作成中・・・"
     Polish     -> "Budowanie " <> p <> "..."
     Croatian   -> "Gradim " <> p <> "..."
@@ -270,7 +269,7 @@ buildFail_6 = \case
 
 -- NEEDS TRANSLATION
 buildFail_7 :: PkgName -> Language -> Doc AnsiStyle
-buildFail_7 (bt . view (field @"name") -> p) = \case
+buildFail_7 (bt . pnName -> p) = \case
     Japanese   -> p <> "のビルドスクリプトを収得できませんでした。"
     Polish     -> "Nie udało się pozyskać skryptów budowania dla " <> p <> "."
     German     -> "Herunterladen der Build-Skripte für " <> p <> " fehlgeschlagen."
@@ -326,7 +325,7 @@ buildFail_11 = \case
 ------------------------------
 -- NEEDS UPDATE TO MATCH NEW ENGLISH
 getRealPkgConflicts_1 :: PkgName -> PkgName -> Text -> Text -> Language -> Doc AnsiStyle
-getRealPkgConflicts_1 (bt . view (field @"name") -> prnt) (bt . view (field @"name") -> p) (bt -> r) (bt -> d) = \case
+getRealPkgConflicts_1 (bt . pnName -> prnt) (bt . pnName -> p) (bt -> r) (bt -> d) = \case
     Japanese   -> "パッケージ" <> p <> "はバージョン" <> d <> "を要するが" <> "一番最新のバージョンは" <> r <> "。"
     Polish     -> "Zależność " <> p <> " powinna być w wersji " <> d <> ", ale najnowsza wersja to " <> r <> "."
     Croatian   -> "Zavisnost " <> p <> " zahtjeva verziju " <> d <> ", a najnovija dostupna verzija je " <> r <> "."
@@ -346,7 +345,7 @@ getRealPkgConflicts_1 (bt . view (field @"name") -> prnt) (bt . view (field @"na
     _          -> "The package " <> prnt <> " depends on version " <> d <> " of " <> p <> ", but the most recent version is " <> r <> "."
 
 getRealPkgConflicts_2 :: PkgName -> Language -> Doc AnsiStyle
-getRealPkgConflicts_2 (bt . view (field @"name") -> p) = \case
+getRealPkgConflicts_2 (bt . pnName -> p) = \case
   Japanese   -> p <> "は無視されるパッケージ！`pacman.conf`を参考に。"
   Polish     -> p <> " jest ignorowany! Sprawdź plik `pacman.conf`."
   Croatian   -> p <> " je ignoriran paket! Provjerite svoj `pacman.conf`."
@@ -401,7 +400,9 @@ missingPkg_4 pns = \case
   Italian    -> vsep $ "Sono stati individuati i seguenti cicli di dipendenza:" : pns'
   Dutch      -> vsep $ "The volgende afhankelijkheidscycli zijn gedetecteerd:" : pns'
   _ -> vsep $ "The following dependency cycles were detected:" : pns'
-  where pns' = map (hsep . map pretty . L.intersperse "=>" . map (view (field @"name")) . toList) pns
+  where
+    pns' :: [Doc ann]
+    pns' = map (hsep . map pretty . L.intersperse "=>" . map pnName . toList) pns
 
 missingPkg_5 :: PkgName -> Language -> Doc AnsiStyle
 missingPkg_5 (PkgName p) = \case
@@ -537,7 +538,7 @@ install_5 = \case
 
 -- 2014 December  7 @ 14:45 - NEEDS TRANSLATIONS
 confirmIgnored_1 :: PkgName -> Language -> Doc AnsiStyle
-confirmIgnored_1 (bt . view (field @"name") -> p) = \case
+confirmIgnored_1 (bt . pnName -> p) = \case
     Japanese   -> p <> "は無視されるはずのパッケージです。それでも続行しますか？"
     Polish     -> p <> " jest oznaczony jako ignorowany. Zainstalować mimo tego?"
     Spanish    -> p <> " está marcado como ignorado. ¿Deseas instalarlo de todas formas?"
@@ -647,7 +648,7 @@ reportPkgsToInstall_3 = \case
 
 -- NEEDS TRANSLATION
 reportPkgbuildDiffs_1 :: PkgName -> Language -> Doc AnsiStyle
-reportPkgbuildDiffs_1 (bt . view (field @"name") -> p) = \case
+reportPkgbuildDiffs_1 (bt . pnName -> p) = \case
     Japanese   -> p <> "のPKGBUILDはまだ保存されていません。"
     Polish     -> p <> " nie ma jeszcze przechowywanego pliku PKGBUILD."
     Croatian   -> p <> " još nema pohranjen PKGBUILD."
@@ -668,7 +669,7 @@ reportPkgbuildDiffs_1 (bt . view (field @"name") -> p) = \case
 
 -- NEEDS TRANSLATION
 reportPkgbuildDiffs_3 :: PkgName -> Language -> Doc AnsiStyle
-reportPkgbuildDiffs_3 (bt . view (field @"name") -> p) = \case
+reportPkgbuildDiffs_3 (bt . pnName -> p) = \case
     Japanese   -> p <> "のPKGBUILD変更報告："
     Polish     -> "Zmiany w PKGBUILD dla " <> p <> ":"
     Croatian   -> "Promjene u PKGBUILD-u za " <> p <> ":"
@@ -902,7 +903,7 @@ readState_1 = \case
 -- Aura/Commands/C functions
 ----------------------------
 getDowngradeChoice_1 :: PkgName -> Language -> Doc AnsiStyle
-getDowngradeChoice_1 (bt . view (field @"name") -> p) = \case
+getDowngradeChoice_1 (bt . pnName -> p) = \case
     Japanese   -> p <> "はどのバージョンにしますか？"
     Polish     -> "Którą wersję pakietu " <> p <> " zainstalować?"
     Croatian   -> "Koju verziju paketa " <> p <> " želite?"
@@ -1460,7 +1461,7 @@ confParsing_1 = \case
     _          -> "Unable to parse your pacman.conf file."
 
 provides_1 :: PkgName -> Language -> Doc AnsiStyle
-provides_1 (bt . view (field @"name") -> pro) = \case
+provides_1 (bt . pnName -> pro) = \case
     Spanish    -> pro <+> "se requiere como una dependencia, que es proporcionada por múltiples paquetes. Por favor, seleccione uno:"
     Italian    -> pro <+> "è richiesto come dipendenza; si trova in molteplici pacchetti. Selezionarne uno:"
     Dutch      -> pro <+> "is vereist als afhankelijkheid, die wordt geleverd door meerdere pakketten. Selecteer er alstublieft een:"
@@ -1470,7 +1471,7 @@ provides_1 (bt . view (field @"name") -> pro) = \case
 -- Aura/Pkgbuild/Editing functions
 ----------------------------------
 hotEdit_1 :: PkgName -> Language -> Doc AnsiStyle
-hotEdit_1 (bt . view (field @"name") -> p) = \case
+hotEdit_1 (bt . pnName -> p) = \case
     Japanese   -> p <> "のPKGBUILDを編成しますか？"
     Polish     -> "Czy chcesz edytować PKGBUILD " <> p <> "?"
     Croatian   -> "Želite li izmjeniti PKGBUILD " <> p <> "?"

--- a/aura/lib/Aura/Languages/Fields.hs
+++ b/aura/lib/Aura/Languages/Fields.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 {-# OPTIONS_HADDOCK prune #-}
 
 -- |

--- a/aura/lib/Aura/Logo.hs
+++ b/aura/lib/Aura/Logo.hs
@@ -9,11 +9,11 @@
 module Aura.Logo ( animateVersionMsg ) where
 
 import           Aura.Colour (dtot, yellow)
+import           Aura.IO
 import           Aura.Languages (translatorMsg)
 import           Aura.Pacman (verMsgPad)
 import           Aura.Settings
 import           Aura.Shell
-import           Aura.Utils
 import           Data.Text.Prettyprint.Doc
 import           RIO
 import qualified RIO.Text as T

--- a/aura/lib/Aura/Logo.hs
+++ b/aura/lib/Aura/Logo.hs
@@ -12,6 +12,7 @@ import           Aura.Colour (dtot, yellow)
 import           Aura.Languages (translatorMsg)
 import           Aura.Pacman (verMsgPad)
 import           Aura.Settings
+import           Aura.Shell
 import           Aura.Utils
 import           Data.Text.Prettyprint.Doc
 import           RIO

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TupleSections #-}
+
 -- |
 -- Module    : Aura.State
 -- Copyright : (c) Colin Woodbury, 2012 - 2020

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -18,7 +18,7 @@ import           Aura.IO (optionalPrompt)
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
-import           Control.Error.Util (note)
+import           Aura.Utils (note)
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import           Lens.Micro (_2)

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -19,8 +19,6 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils (note)
-import           Data.Set.NonEmpty (NESet)
-import qualified Data.Set.NonEmpty as NES
 import           Lens.Micro (_2)
 import           RIO
 import qualified RIO.ByteString.Lazy as BL
@@ -41,11 +39,11 @@ makepkgCmd = fromAbsoluteFilePath "/usr/bin/makepkg"
 
 -- | Given the current user name, build the package of whatever
 -- directory we're in.
-makepkg :: Settings -> User -> IO (Either Failure (NESet (Path Absolute)))
+makepkg :: Settings -> User -> IO (Either Failure (NonEmpty (Path Absolute)))
 makepkg ss usr = make ss usr (proc cmd $ opts <> colour) >>= g
   where
     (cmd, opts) = runStyle usr . map T.unpack . foldMap asFlag . makepkgFlagsOf $ buildConfigOf ss
-    g (ExitSuccess, _, fs)   = pure . note (Failure buildFail_9) . fmap NES.fromList $ NEL.nonEmpty fs
+    g (ExitSuccess, _, fs)   = pure . note (Failure buildFail_9) $ NEL.nonEmpty fs
     g (ExitFailure _, se, _) = do
       unless (switch ss DontSuppressMakepkg) $ do
         showError <- optionalPrompt ss buildFail_11

--- a/aura/lib/Aura/MakePkg.hs
+++ b/aura/lib/Aura/MakePkg.hs
@@ -14,10 +14,10 @@ module Aura.MakePkg
   , makepkgConfFile
   ) where
 
+import           Aura.IO (optionalPrompt)
 import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (optionalPrompt)
 import           Control.Error.Util (note)
 import           Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
@@ -27,7 +27,6 @@ import qualified RIO.ByteString.Lazy as BL
 import qualified RIO.NonEmpty as NEL
 import qualified RIO.Text as T
 import           System.Path
-    (Absolute, Path, fromAbsoluteFilePath, toFilePath, (</>))
 import           System.Path.IO (getCurrentDirectory, getDirectoryContents)
 import           System.Process.Typed
 

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -30,8 +30,7 @@ import           Aura.Languages
 import           Aura.Pkgbuild.Fetch
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils (fmapEither, groupsOf)
-import           Control.Error.Util (hush, note)
+import           Aura.Utils
 import           Control.Monad.Trans.Maybe
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE TypeApplications      #-}
 -- |
 -- Module    : Aura.Packages.AUR
 -- Copyright : (c) Colin Woodbury, 2012 - 2020

--- a/aura/lib/Aura/Packages/Repository.hs
+++ b/aura/lib/Aura/Packages/Repository.hs
@@ -22,8 +22,7 @@ import           Aura.Languages (provides_1)
 import           Aura.Pacman (pacmanLines, pacmanOutput)
 import           Aura.Settings (CommonSwitch(..), Settings(..), shared)
 import           Aura.Types
-import           Aura.Utils (fmapEither, traverseEither)
-import           Control.Error.Util (hush, note)
+import           Aura.Utils
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)
 import qualified Data.Set.NonEmpty as NES

--- a/aura/lib/Aura/Packages/Repository.hs
+++ b/aura/lib/Aura/Packages/Repository.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
 
 -- |
 -- Module    : Aura.Packages.Repository

--- a/aura/lib/Aura/Packages/Repository.hs
+++ b/aura/lib/Aura/Packages/Repository.hs
@@ -17,11 +17,12 @@ module Aura.Packages.Repository
   ) where
 
 import           Aura.Core
+import           Aura.IO
 import           Aura.Languages (provides_1)
 import           Aura.Pacman (pacmanLines, pacmanOutput)
 import           Aura.Settings (CommonSwitch(..), Settings(..), shared)
 import           Aura.Types
-import           Aura.Utils (fmapEither, getSelection, traverseEither)
+import           Aura.Utils (fmapEither, traverseEither)
 import           Control.Error.Util (hush, note)
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)

--- a/aura/lib/Aura/Packages/Repository.hs
+++ b/aura/lib/Aura/Packages/Repository.hs
@@ -25,7 +25,6 @@ import           Aura.Types
 import           Aura.Utils
 import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Generics.Product (field)
-import qualified Data.Set.NonEmpty as NES
 import           Data.Versions
 import           RIO hiding (try)
 import qualified RIO.Map as M
@@ -41,7 +40,7 @@ pacmanRepo :: IO Repository
 pacmanRepo = do
   tv <- newTVarIO mempty
 
-  let g :: Settings -> NES.NESet PkgName -> IO (Maybe (Set PkgName, Set Package))
+  let g :: Settings -> NonEmpty PkgName -> IO (Maybe (Set PkgName, Set Package))
       g ss names = do
         --- Retrieve cached Packages ---
         cache <- readTVarIO tv

--- a/aura/lib/Aura/Pacman.hs
+++ b/aura/lib/Aura/Pacman.hs
@@ -32,8 +32,7 @@ module Aura.Pacman
 import           Aura.Languages
 import           Aura.Types
 import           Data.Bifunctor (first)
-import           Lens.Micro (at, (^?), _2, _Just, _head)
-import           Lens.Micro.GHC ()
+import           Lens.Micro (_2)
 import           RIO hiding (first, some, try)
 import qualified RIO.ByteString as BS
 import qualified RIO.ByteString.Lazy as BL
@@ -107,11 +106,13 @@ groupPackages igs = fmap (f . decodeUtf8Lenient) . pacmanOutput $ "-Qg" : asFlag
 
 -- | Fetches the @CacheDir@ entry from the config, if it's there.
 getCachePath :: Config -> Maybe (Path Absolute)
-getCachePath (Config c) = c ^? at "CacheDir" . _Just . _head . to (fromAbsoluteFilePath . T.unpack)
+getCachePath (Config c) =
+  M.lookup "CacheDir" c >>= listToMaybe >>= pure . fromAbsoluteFilePath . T.unpack
 
 -- | Fetches the @LogFile@ entry from the config, if it's there.
 getLogFilePath :: Config -> Maybe (Path Absolute)
-getLogFilePath (Config c) = c ^? at "LogFile" . _Just . _head . to (fromAbsoluteFilePath . T.unpack)
+getLogFilePath (Config c) =
+  M.lookup "LogFile" c >>= listToMaybe >>= pure . fromAbsoluteFilePath . T.unpack
 
 ----------
 -- ACTIONS

--- a/aura/lib/Aura/Pacman.hs
+++ b/aura/lib/Aura/Pacman.hs
@@ -32,7 +32,6 @@ module Aura.Pacman
 import           Aura.Languages
 import           Aura.Types
 import           Data.Bifunctor (first)
-import           Data.Set.NonEmpty (NESet)
 import           Lens.Micro (at, (^?), _2, _Just, _head)
 import           Lens.Micro.GHC ()
 import           RIO hiding (first, some, try)
@@ -100,7 +99,7 @@ getIgnoredGroups :: Config -> Set PkgGroup
 getIgnoredGroups (Config c) = maybe S.empty (S.fromList . map PkgGroup) $ M.lookup "IgnoreGroup" c
 
 -- | Given a `Set` of package groups, yield all the packages they contain.
-groupPackages :: NESet PkgGroup -> IO (Set PkgName)
+groupPackages :: NonEmpty PkgGroup -> IO (Set PkgName)
 groupPackages igs = fmap (f . decodeUtf8Lenient) . pacmanOutput $ "-Qg" : asFlag igs
   where
     f :: Text -> Set PkgName

--- a/aura/lib/Aura/Pkgbuild/Editing.hs
+++ b/aura/lib/Aura/Pkgbuild/Editing.hs
@@ -11,10 +11,10 @@
 
 module Aura.Pkgbuild.Editing ( hotEdit ) where
 
+import Aura.IO
 import Aura.Languages
 import Aura.Settings
 import Aura.Types
-import Aura.Utils
 import Data.Generics.Product (field)
 import Lens.Micro ((.~))
 import RIO

--- a/aura/lib/Aura/Pkgbuild/Editing.hs
+++ b/aura/lib/Aura/Pkgbuild/Editing.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Pkgbuild.Base

--- a/aura/lib/Aura/Pkgbuild/Fetch.hs
+++ b/aura/lib/Aura/Pkgbuild/Fetch.hs
@@ -17,7 +17,6 @@ module Aura.Pkgbuild.Fetch
 
 import           Aura.Types (PkgName(..), Pkgbuild(..))
 import           Aura.Utils (urlContents)
-import           Data.Generics.Product (field)
 import           Network.HTTP.Client (Manager)
 import           Network.URI (escapeURIString, isUnescapedInURIComponent)
 import           RIO
@@ -37,7 +36,7 @@ pkgbuildUrl p = baseUrl </> "cgit/aur.git/plain/PKGBUILD?h="
 -- | The PKGBUILD of a given package, retrieved from the AUR servers.
 getPkgbuild :: Manager -> PkgName -> IO (Maybe Pkgbuild)
 getPkgbuild m p = e $ do
-  t <- urlContents m . pkgbuildUrl . T.unpack $ p ^. field @"name"
+  t <- urlContents m . pkgbuildUrl . T.unpack $ pnName p
   pure $ fmap Pkgbuild t
   where
     -- TODO Make this less "baby's first Haskell".

--- a/aura/lib/Aura/Pkgbuild/Fetch.hs
+++ b/aura/lib/Aura/Pkgbuild/Fetch.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 -- |
 -- Module    : Aura.State

--- a/aura/lib/Aura/Pkgbuild/Records.hs
+++ b/aura/lib/Aura/Pkgbuild/Records.hs
@@ -16,7 +16,6 @@ module Aura.Pkgbuild.Records
 
 import Aura.Pkgbuild.Base
 import Aura.Types
-import Data.Generics.Product (field)
 import RIO
 import System.Path (toFilePath)
 import System.Path.IO (createDirectoryIfMissing, doesFileExist)
@@ -32,7 +31,7 @@ hasPkgbuildStored = doesFileExist . pkgbuildPath
 storePkgbuilds :: NonEmpty Buildable -> IO ()
 storePkgbuilds bs = do
   createDirectoryIfMissing True pkgbuildCache
-  traverse_ (\p -> writePkgbuild (p ^. field @"name") (p ^. field @"pkgbuild")) bs
+  traverse_ (\p -> writePkgbuild (bName p) (bPkgbuild p)) bs
 
 writePkgbuild :: PkgName -> Pkgbuild -> IO ()
 writePkgbuild pn (Pkgbuild pb) = writeFileBinary (toFilePath $ pkgbuildPath pn) pb

--- a/aura/lib/Aura/Pkgbuild/Records.hs
+++ b/aura/lib/Aura/Pkgbuild/Records.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Pkgbuild.Records

--- a/aura/lib/Aura/Pkgbuild/Records.hs
+++ b/aura/lib/Aura/Pkgbuild/Records.hs
@@ -17,7 +17,6 @@ module Aura.Pkgbuild.Records
 import Aura.Pkgbuild.Base
 import Aura.Types
 import Data.Generics.Product (field)
-import Data.Set.NonEmpty (NESet)
 import RIO
 import System.Path (toFilePath)
 import System.Path.IO (createDirectoryIfMissing, doesFileExist)
@@ -30,7 +29,7 @@ hasPkgbuildStored :: PkgName -> IO Bool
 hasPkgbuildStored = doesFileExist . pkgbuildPath
 
 -- | Write the PKGBUILDs of some `Buildable`s to disk.
-storePkgbuilds :: NESet Buildable -> IO ()
+storePkgbuilds :: NonEmpty Buildable -> IO ()
 storePkgbuilds bs = do
   createDirectoryIfMissing True pkgbuildCache
   traverse_ (\p -> writePkgbuild (p ^. field @"name") (p ^. field @"pkgbuild")) bs

--- a/aura/lib/Aura/Pkgbuild/Security.hs
+++ b/aura/lib/Aura/Pkgbuild/Security.hs
@@ -18,7 +18,7 @@ module Aura.Pkgbuild.Security
 
 import           Aura.Languages
 import           Aura.Types (Language, Pkgbuild(..))
-import           Control.Error.Util (hush)
+import           Aura.Utils (hush)
 import           Data.Generics.Product (typed, types)
 import           Data.Text.Prettyprint.Doc (Doc)
 import           Data.Text.Prettyprint.Doc.Render.Terminal (AnsiStyle)

--- a/aura/lib/Aura/Pkgbuild/Security.hs
+++ b/aura/lib/Aura/Pkgbuild/Security.hs
@@ -19,12 +19,11 @@ module Aura.Pkgbuild.Security
 import           Aura.Languages
 import           Aura.Types (Language, Pkgbuild(..))
 import           Aura.Utils (hush)
-import           Data.Generics.Product (typed, types)
 import           Data.Text.Prettyprint.Doc (Doc)
 import           Data.Text.Prettyprint.Doc.Render.Terminal (AnsiStyle)
 import           Language.Bash.Parse (parse)
 import           Language.Bash.Syntax
-import           Language.Bash.Word (Span(..), Word, unquote)
+import           Language.Bash.Word
 import           Lens.Micro (each, (.~), (^..), _Just)
 import           RIO hiding (Word)
 import qualified RIO.Map as M
@@ -35,6 +34,9 @@ import qualified RIO.Text as T
 -- | A bash term which should never appear in a PKGBUILD. If one does, it's
 -- either a sign of maintainer negligence or malicious behaviour.
 data BannedTerm = BannedTerm Text BanCategory deriving (Eq, Ord, Show, Generic)
+
+banCatL :: Lens' BannedTerm BanCategory
+banCatL f (BannedTerm t bc) = (\bc' -> BannedTerm t bc') <$> f bc
 
 -- | The reason why the bash term is black-listed.
 data BanCategory = Downloading
@@ -67,27 +69,89 @@ banned w = M.lookup (T.pack $ unquote w) blacklist
 
 -- | Extract all `SimpleCommand`s from a parsed bash AST.
 simpleCommands :: List -> [ShellCommand]
-simpleCommands l = l ^.. types @ShellCommand . to p . each
-  where p sc@(SimpleCommand _ _) = [sc]
-        p sc = sc ^.. types @List . to simpleCommands . each
+simpleCommands (List ss) = ss >>= statements >>= p
+  where
+    p :: ShellCommand -> [ShellCommand]
+    p sc@(SimpleCommand _ _) = [sc]
+    p sc                     = lists sc >>= simpleCommands
+
+    statements :: Statement -> [ShellCommand]
+    statements (Statement ao _) = andor ao
+
+    andor :: AndOr -> [ShellCommand]
+    andor (Last pl)   = pipeline pl
+    andor (And pl ao) = pipeline pl <> andor ao
+    andor (Or pl ao)  = pipeline pl <> andor ao
+
+    pipeline :: Pipeline -> [ShellCommand]
+    pipeline (Pipeline _ _ _ cs) = map command cs
+
+    command :: Command -> ShellCommand
+    command (Command sc _) = sc
+
+    lists :: ShellCommand -> [List]
+    lists (SimpleCommand _ _) = []
+    lists (AssignBuiltin _ _) = []
+    lists (FunctionDef _ l)   = [l]
+    lists (Coproc _ c)        = lists $ command c
+    lists (Subshell l)        = [l]
+    lists (Group l)           = [l]
+    lists (Arith _)           = []
+    lists (Cond _)            = []
+    lists (For _ _ l)         = [l]
+    lists (ArithFor _ l)      = [l]
+    lists (Select _ _ l)      = [l]
+    lists (Case _ ccs)        = map caseClause ccs
+    lists (If l1 l2 ml)       = l1 : l2 : maybeToList ml
+    lists (Until l1 l2)       = [l1, l2]
+    lists (While l1 l2)       = [l1, l2]
+
+    caseClause :: CaseClause -> List
+    caseClause (CaseClause _ l _) = l
 
 bannedCommand :: ShellCommand -> [(ShellCommand, BannedTerm)]
 bannedCommand s@(SimpleCommand [] (g:c:_))
   | g == [Char 'g', Char 'i', Char 't'] &&
     c == [Char 'c', Char 'l', Char 'o', Char 'n', Char 'e'] = [(s, BannedTerm "git" Downloading)]
 bannedCommand s@(SimpleCommand [] (c:_)) = maybeToList $ (s,) <$> banned c
-bannedCommand s@(SimpleCommand as _) = as ^.. each . typed @RValue . to r . each
+bannedCommand s@(SimpleCommand as _) = as ^.. each . rValueL . to r . each
   where
-    r rv@(RValue w) = maybeToList ((s,) <$> (banned w & _Just . typed @BanCategory .~ CleverRedirect)) <> q rv
+    r rv@(RValue w) = maybeToList ((s,) <$> (banned w & _Just . banCatL .~ CleverRedirect)) <> q rv
     r rv = q rv
 
     q :: RValue -> [(ShellCommand, BannedTerm)]
-    q rv = rv ^.. types @Word . each . to p . each . to (s,)
+    q rv = map (s,) $ rWords rv >>= id >>= p
 
+    p :: Span -> [BannedTerm]
     p (CommandSubst str)   = maybeToList (hush $ parse "CommandSubst" str) >>= simpleCommands >>= map snd . bannedCommand
     p (ArithSubst str)     = [BannedTerm (T.pack str) StrangeBashism]
     p (ProcessSubst _ str) = [BannedTerm (T.pack str) StrangeBashism]
-    p sp = sp ^.. types @Word . each . to p . each
+    p sp = sWords sp >>= id >>= p
+
+    rWords :: RValue -> [Word]
+    rWords (RValue w)  = [w]
+    rWords (RArray ws) = ws >>= \(mw, w) -> w : maybeToList mw
+
+    sWords :: Span -> [Word]
+    sWords (Single w)      = [w]
+    sWords (Double w)      = [w]
+    sWords (ANSIC w)       = [w]
+    sWords (Locale w)      = [w]
+    sWords (Backquote w)   = [w]
+    sWords (ParamSubst ps) = subWords ps
+    sWords _               = []
+
+    subWords :: ParamSubst -> [Word]
+    subWords (Bare (Parameter _ mw))                = maybeToList mw
+    subWords (Brace _ (Parameter _ mw))             = maybeToList mw
+    subWords (Alt _ (Parameter _ mw) _ _ w)         = w : maybeToList mw
+    subWords (Substring _ (Parameter _ mw) w1 w2)   = w1 : w2 : maybeToList mw
+    subWords (Prefix _ _)                           = []
+    subWords (Indices (Parameter _ mw))             = maybeToList mw
+    subWords (Length (Parameter _ mw))              = maybeToList mw
+    subWords (Delete _ (Parameter _ mw) _ _ w)      = w : maybeToList mw
+    subWords (Replace _ (Parameter _ mw) _ _ w1 w2) = w1 : w2 : maybeToList mw
+    subWords (LetterCase _ (Parameter _ mw) _ _ w)  = w : maybeToList mw
 bannedCommand _ = []
 
 ------------
@@ -103,3 +167,10 @@ reportExploit (BannedTerm t bc) = case bc of
   InlinedBash    -> security_8 t
   StrangeBashism -> security_9 t
   CleverRedirect -> security_10 t
+
+--------
+-- UTILS
+--------
+
+rValueL :: Lens' Assign RValue
+rValueL f (Assign p ao r) = (\r' -> Assign p ao r') <$> f r

--- a/aura/lib/Aura/Pkgbuild/Security.hs
+++ b/aura/lib/Aura/Pkgbuild/Security.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.Pkgbuild.Security

--- a/aura/lib/Aura/Settings.hs
+++ b/aura/lib/Aura/Settings.hs
@@ -122,6 +122,7 @@ data Settings = Settings
   , ignoresOf      :: !(Set PkgName)
   , commonConfigOf :: !CommonConfig
   , buildConfigOf  :: !BuildConfig
+  , logLevelOf     :: !LogLevel
   , logFuncOf      :: !LogFunc }
   deriving stock (Generic)
 

--- a/aura/lib/Aura/Settings.hs
+++ b/aura/lib/Aura/Settings.hs
@@ -11,6 +11,7 @@
 
 module Aura.Settings
   ( Settings(..)
+  , logFuncOfL
     -- * Aura Configuration
   , BuildConfig(..), BuildSwitch(..)
   , switch
@@ -125,6 +126,9 @@ data Settings = Settings
   , logLevelOf     :: !LogLevel
   , logFuncOf      :: !LogFunc }
   deriving stock (Generic)
+
+logFuncOfL :: Lens' Settings LogFunc
+logFuncOfL f s = (\lf -> s { logFuncOf = lf }) <$> f (logFuncOf s)
 
 -- | Unless otherwise specified, packages will be built within @/tmp@.
 defaultBuildDir :: Path Absolute

--- a/aura/lib/Aura/Shell.hs
+++ b/aura/lib/Aura/Shell.hs
@@ -1,3 +1,11 @@
+-- |
+-- Module    : Aura.Shell
+-- Copyright : (c) Colin Woodbury, 2012 - 2020
+-- License   : GPL3
+-- Maintainer: Colin Woodbury <colin@fosskers.ca>
+--
+-- Interaction with the terminal.
+
 module Aura.Shell where
 
 import           Aura.Types

--- a/aura/lib/Aura/Shell.hs
+++ b/aura/lib/Aura/Shell.hs
@@ -1,0 +1,64 @@
+module Aura.Shell where
+
+import           Aura.Types
+import           RIO
+import qualified RIO.ByteString as B
+import qualified RIO.Map as M
+import qualified RIO.Text as T
+import           System.Path (Absolute, Path, toFilePath)
+import           System.Process.Typed (proc, runProcess)
+
+---
+
+-- | Code borrowed from `ansi-terminal` library by Max Bolingbroke.
+csi :: [Int] -> ByteString -> ByteString
+csi args code = "\ESC[" <> B.intercalate ";" (map (encodeUtf8 . textDisplay) args) <> code
+
+-- | Terminal code for raising the cursor.
+cursorUpLineCode :: Int -> ByteString
+cursorUpLineCode n = csi [n] "F"
+
+-- | This will get the true user name regardless of sudo-ing.
+getTrueUser :: Environment -> Maybe User
+getTrueUser env | isTrueRoot env  = Just $ User "root"
+                | hasRootPriv env = User <$> M.lookup "SUDO_USER" env
+                | otherwise       = User <$> M.lookup "USER" env
+
+-- | Is the current user of Aura the true @root@ user, and not just a sudo user?
+isTrueRoot :: Environment -> Bool
+isTrueRoot env = M.lookup "USER" env == Just "root" && not (M.member "SUDO_USER" env)
+
+-- | Is the user root, or using sudo?
+hasRootPriv :: Environment -> Bool
+hasRootPriv env = M.member "SUDO_USER" env || isTrueRoot env
+
+-- | `vi` is a sensible default, it should be installed by
+-- on any Arch system.
+getEditor :: Environment -> FilePath
+getEditor = maybe "vi" T.unpack . M.lookup "EDITOR"
+
+-- | This will get the locale variable for translations from the environment
+getLocale :: Environment -> Text
+getLocale env = fromMaybe "C" . asum $ map (`M.lookup` env) ["LC_ALL", "LC_MESSAGES", "LANG"]
+
+-- | Mark some `Path` as being owned by a `User`.
+chown :: MonadIO m => User -> Path Absolute -> [String] -> m ()
+chown (User usr) pth args = void . runProcess $ proc "chown" (args <> [T.unpack usr, toFilePath pth])
+
+-- | Hide the cursor in a terminal.
+hideCursor :: IO ()
+hideCursor = B.putStr hideCursorCode
+
+-- | Restore a cursor to visiblity in the terminal.
+showCursor :: IO ()
+showCursor = B.putStr showCursorCode
+
+hideCursorCode :: ByteString
+hideCursorCode = csi [] "?25l"
+
+showCursorCode :: ByteString
+showCursorCode = csi [] "?25h"
+
+-- | Raise the cursor by @n@ lines.
+raiseCursorBy :: Int -> IO ()
+raiseCursorBy = B.putStr . cursorUpLineCode

--- a/aura/lib/Aura/State.hs
+++ b/aura/lib/Aura/State.hs
@@ -27,7 +27,7 @@ import           Aura.Languages
 import           Aura.Pacman (pacman, pacmanLines)
 import           Aura.Settings
 import           Aura.Types
-import           Control.Error.Util (hush)
+import           Aura.Utils (hush)
 import           Data.Aeson
 import           Data.Generics.Product (field)
 import           Data.Versions

--- a/aura/lib/Aura/State.hs
+++ b/aura/lib/Aura/State.hs
@@ -22,11 +22,11 @@ module Aura.State
 import           Aura.Cache
 import           Aura.Colour (red)
 import           Aura.Core (Env(..), notify, report, warn)
+import           Aura.IO
 import           Aura.Languages
 import           Aura.Pacman (pacman, pacmanLines)
 import           Aura.Settings
 import           Aura.Types
-import           Aura.Utils
 import           Control.Error.Util (hush)
 import           Data.Aeson
 import           Data.Generics.Product (field)

--- a/aura/lib/Aura/State.hs
+++ b/aura/lib/Aura/State.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module    : Aura.State

--- a/aura/lib/Aura/State.hs
+++ b/aura/lib/Aura/State.hs
@@ -29,7 +29,6 @@ import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils (hush)
 import           Data.Aeson
-import           Data.Generics.Product (field)
 import           Data.Versions
 import           RIO
 import qualified RIO.ByteString.Lazy as BL
@@ -147,7 +146,7 @@ restoreState =
               Cache cache <- liftIO $ cacheContents pth
               let StateDiff rein remo = compareStates past curr
                   (okay, nope)        = L.partition (`M.member` cache) rein
-              traverse_ (report red restoreState_1 . fmap (^. field @"name")) $ NEL.nonEmpty nope
+              traverse_ (report red restoreState_1 . fmap spName) $ NEL.nonEmpty nope
               reinstallAndRemove (mapMaybe (`M.lookup` cache) okay) remo
 
 selectState :: NonEmpty (Path Absolute) -> IO (Path Absolute)
@@ -168,4 +167,4 @@ reinstallAndRemove down remo
   | otherwise = reinstall *> remove
   where
     remove    = liftIO . pacman $ "-R" : asFlag remo
-    reinstall = liftIO . pacman $ "-U" : map (T.pack . toFilePath . path) down
+    reinstall = liftIO . pacman $ "-U" : map (T.pack . toFilePath . ppPath) down

--- a/aura/lib/Aura/Types.hs
+++ b/aura/lib/Aura/Types.hs
@@ -44,7 +44,7 @@ module Aura.Types
   , User(..)
   ) where
 
-import           Control.Error.Util (hush)
+import           Aura.Utils (hush)
 import           Data.Aeson (FromJSONKey, ToJSONKey)
 import           Data.Bifunctor (Bifunctor(..))
 import           Data.Bitraversable

--- a/aura/lib/Aura/Types.hs
+++ b/aura/lib/Aura/Types.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiWayIf                 #-}
+{-# LANGUAGE TypeApplications           #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/aura/lib/Aura/Utils.hs
+++ b/aura/lib/Aura/Utils.hs
@@ -17,6 +17,8 @@ module Aura.Utils
   , fmapEither
   , traverseEither
   , groupsOf
+  , hush
+  , note
   ) where
 
 import           Network.HTTP.Client
@@ -80,3 +82,9 @@ groupsOf n as
     go bs = xs : go rest
       where
         (xs, rest) = L.splitAt n bs
+
+hush :: Either a b -> Maybe b
+hush = either (const Nothing) Just
+
+note :: a -> Maybe b -> Either a b
+note a = maybe (Left a) Right

--- a/aura/lib/Aura/Utils.hs
+++ b/aura/lib/Aura/Utils.hs
@@ -12,11 +12,6 @@ module Aura.Utils
   , searchLines
     -- * Network
   , urlContents
-    -- * Shell
-  , csi, cursorUpLineCode, hideCursor, showCursor, raiseCursorBy
-  , getTrueUser, getEditor, getLocale
-  , hasRootPriv, isTrueRoot
-  , chown
     -- * Output
   , putStrLnA
   , putText
@@ -36,7 +31,7 @@ module Aura.Utils
 import           Aura.Colour
 import           Aura.Languages (whitespace, yesNoMessage, yesPattern)
 import           Aura.Settings
-import           Aura.Types (Environment, Language, User(..))
+import           Aura.Types (Language)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           Network.HTTP.Client
@@ -46,10 +41,7 @@ import qualified RIO.ByteString as B
 import qualified RIO.ByteString.Lazy as BL
 import qualified RIO.List as L
 import           RIO.List.Partial (maximum)
-import qualified RIO.Map as M
 import qualified RIO.Text as T
-import           System.Path (Absolute, Path, toFilePath)
-import           System.Process.Typed (proc, runProcess)
 import           Text.Printf (printf)
 
 ---
@@ -92,62 +84,6 @@ urlContents m url = f <$> httpLbs (parseRequest_ url) m
     f :: Response BL.ByteString -> Maybe ByteString
     f res | statusCode (responseStatus res) == 200 = Just . BL.toStrict $ responseBody res
           | otherwise = Nothing
-
---------
--- SHELL
---------
--- | Code borrowed from `ansi-terminal` library by Max Bolingbroke.
-csi :: [Int] -> ByteString -> ByteString
-csi args code = "\ESC[" <> B.intercalate ";" (map (encodeUtf8 . textDisplay) args) <> code
-
--- | Terminal code for raising the cursor.
-cursorUpLineCode :: Int -> ByteString
-cursorUpLineCode n = csi [n] "F"
-
--- | This will get the true user name regardless of sudo-ing.
-getTrueUser :: Environment -> Maybe User
-getTrueUser env | isTrueRoot env  = Just $ User "root"
-                | hasRootPriv env = User <$> M.lookup "SUDO_USER" env
-                | otherwise       = User <$> M.lookup "USER" env
-
--- | Is the current user of Aura the true @root@ user, and not just a sudo user?
-isTrueRoot :: Environment -> Bool
-isTrueRoot env = M.lookup "USER" env == Just "root" && not (M.member "SUDO_USER" env)
-
--- | Is the user root, or using sudo?
-hasRootPriv :: Environment -> Bool
-hasRootPriv env = M.member "SUDO_USER" env || isTrueRoot env
-
--- | `vi` is a sensible default, it should be installed by
--- on any Arch system.
-getEditor :: Environment -> FilePath
-getEditor = maybe "vi" T.unpack . M.lookup "EDITOR"
-
--- | This will get the locale variable for translations from the environment
-getLocale :: Environment -> Text
-getLocale env = fromMaybe "C" . asum $ map (`M.lookup` env) ["LC_ALL", "LC_MESSAGES", "LANG"]
-
--- | Mark some `Path` as being owned by a `User`.
-chown :: MonadIO m => User -> Path Absolute -> [String] -> m ()
-chown (User usr) pth args = void . runProcess $ proc "chown" (args <> [T.unpack usr, toFilePath pth])
-
--- | Hide the cursor in a terminal.
-hideCursor :: IO ()
-hideCursor = B.putStr hideCursorCode
-
--- | Restore a cursor to visiblity in the terminal.
-showCursor :: IO ()
-showCursor = B.putStr showCursorCode
-
-hideCursorCode :: ByteString
-hideCursorCode = csi [] "?25l"
-
-showCursorCode :: ByteString
-showCursorCode = csi [] "?25h"
-
--- | Raise the cursor by @n@ lines.
-raiseCursorBy :: Int -> IO ()
-raiseCursorBy = B.putStr . cursorUpLineCode
 
 ----------------
 -- CUSTOM OUTPUT

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.5
+resolver: lts-15.6
 
 ghc-options: {"$locals": -fwrite-ide-info}
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -27,7 +27,7 @@ packages:
     hackage: witherable-class-0
 snapshots:
 - completed:
-    size: 491372
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/5.yaml
-    sha256: 1b549cfff328040c382a70a84a2087aac8dab6d778bf92f32a93a771a1980dfc
-  original: lts-15.5
+    size: 491387
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/6.yaml
+    sha256: 8d81505a6de861e167a58534ab62330afb75bfa108735c7db1204f7ef2a39d79
+  original: lts-15.6


### PR DESCRIPTION
This PR removes a number of dependencies from Aura's dep graph, such that the binary comes out smaller, and Aura is less bound to the development cycles of so many other packages.

```
| Stage               | Exec Size | Deps |
|---------------------+-----------+------|
| Initial             |      30.9 |  140 |
| servant             |      28.3 |  118 |
| errors              |      28.3 |  116 |
| mwc-random          |      27.7 |  113 |
| pretty-simple       |      27.4 |  112 |
| nonempty-containers |      27.0 |  108 |
| generic-lens        |      26.4 |  101 |
| aeson-pretty        |      26.3 |   99 |
| microlens-ghc       |      26.2 |   98 |
```
Compile times have been reduced by ~40%.