### PR TITLE
Fix Portuguese flag

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 
 | Build                                                      | Release                                   | Chat                                               | Downloads                                                       | Languages                                                                                                         |
 |------------------------------------------------------------+-------------------------------------------+----------------------------------------------------+-----------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------|
-| [[https://github.com/fosskers/aura/workflows/Tests/badge.svg]] | [[http://hackage.haskell.org/package/aura][https://img.shields.io/hackage/v/aura.svg]] | [[https://gitter.im/aurapm/aura][https://img.shields.io/gitter/room/aurapm/aura.svg]] | [[https://img.shields.io/github/downloads/fosskers/aura/total.svg]] | :uk: :jp: :croatia: :sweden: :de: :es: :portugal: :fr: :ru: :it: :serbia: :norway: :indonesia: :cn: :netherlands: |
+| [[https://github.com/fosskers/aura/workflows/Tests/badge.svg]] | [[http://hackage.haskell.org/package/aura][https://img.shields.io/hackage/v/aura.svg]] | [[https://gitter.im/aurapm/aura][https://img.shields.io/gitter/room/aurapm/aura.svg]] | [[https://img.shields.io/github/downloads/fosskers/aura/total.svg]] | :uk: :jp: :croatia: :sweden: :de: :es: :brazil: :fr: :ru: :it: :serbia: :norway: :indonesia: :cn: :netherlands: |
 
 Welcome to the main repository for Aura, a secure, multilingual package manager
 for Arch Linux.


### PR DESCRIPTION
The Portuguese language went through a recent reform (2016) where the Brazilian version was adopted as the standard for all Portuguese speaking countries, like Portugal. Also Portuguese is spoken by around 220 million native speakers, 210 million which are Brazilians, and around 10 million Portuguese. In a total of 250 million including non-native speakers, worldwide. New learning speakers usually comes in contact with the language through Brazil. Having Portugal's flag is miss-representative of the language as of right now, post reform. It does has historical value as the origin of the language, but no longer represents it.

- The decree establishing the reform process: https://www.lexml.gov.br/urn/urn:lex:br:federal:decreto:2012-12-27;7875
- About the Portuguese Language Reforms: https://en.wikipedia.org/wiki/Reforms_of_Portuguese_orthography
- More about the Portuguese language: https://en.wikipedia.org/wiki/Portuguese_language