### PR TITLE
Remove More Dependencies

### DIFF
--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 #### Changed
 
-- ~15% reduction in binary size and must faster compiles due to removal of
+- ~15% reduction in binary size and much faster compiles due to removal of
   unnecessary dependencies.
 - A few more messages when using `--log-level=debug`.
 

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -99,7 +99,6 @@ library
     , network-uri       ^>=2.6
     , scheduler         >=1.1  && <1.5
     , stm               ^>=2.5
-    , these             ^>=1.0
     , time              >=1.8  && <1.10
     , unliftio          ^>=0.2
 

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -102,7 +102,6 @@ library
     , these             ^>=1.0
     , time              >=1.8  && <1.10
     , unliftio          ^>=0.2
-    , witherable-class  ^>=0
 
 executable aura
   import:         commons, libexec

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -39,7 +39,6 @@ common commons
     , bytestring  ^>=0.10
     , containers  ^>=0.6
     , microlens   ^>=0.4
-    , paths       ^>=0.2
     , rio         ^>=0.1.13
     , text        ^>=1.2
     , versions    ^>=3.5

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -54,7 +54,6 @@ import Flags
 import Options.Applicative (execParser)
 import RIO hiding (first)
 import Settings
-import System.Path (toFilePath)
 import System.Process.Typed (proc, runProcess)
 
 ---
@@ -152,4 +151,4 @@ displayOutputLanguages = do
 viewConfFile :: RIO Env ()
 viewConfFile = do
   pth <- asks (either id id . configPathOf . commonConfigOf . settings)
-  void . runProcess $ proc "less" [toFilePath pth]
+  void . runProcess $ proc "less" [pth]

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -23,7 +23,6 @@ import           Aura.Types
 import           Aura.Utils
 import           Control.Monad.Trans.Except
 import           Data.Hashable (hash)
-import           Data.Witherable.Class (wither)
 import           RIO
 import           RIO.Directory (setCurrentDirectory)
 import qualified RIO.NonEmpty as NEL
@@ -49,8 +48,10 @@ installPkgFiles files = do
 -- | All building occurs within temp directories,
 -- or in a location specified by the user with flags.
 buildPackages :: NonEmpty Buildable -> RIO Env (NonEmpty PackagePath)
-buildPackages bs = wither build (NEL.toList bs) >>= maybe bad (pure . fold1) . NEL.nonEmpty
-  where bad = throwM $ Failure buildFail_10
+buildPackages bs = mapMaybeA build (NEL.toList bs) >>= maybe bad (pure . fold1) . NEL.nonEmpty
+  where
+    bad :: RIO Env a
+    bad = throwM $ Failure buildFail_10
 
 -- | Handles the building of Packages. Fails nicely.
 -- Assumed: All dependencies are already installed.

--- a/aura/lib/Aura/Commands/B.hs
+++ b/aura/lib/Aura/Commands/B.hs
@@ -22,11 +22,11 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.State
 import           RIO
+import           RIO.Directory
+import           RIO.FilePath
 import qualified RIO.List as L
 import qualified RIO.NonEmpty as NEL
 import qualified RIO.Text as T
-import           System.Path (takeFileName, toFilePath, toUnrootedFilePath)
-import           System.Path.IO (removeFile)
 
 ---
 
@@ -38,7 +38,7 @@ cleanStates ss (fromIntegral -> n) = do
   warn ss . cleanStates_4 (length stfs) $ langOf ss
   unless (null pinned) . warn ss . cleanStates_6 (length pinned) $ langOf ss
   forM_ (NEL.nonEmpty stfs) $ \stfs' -> do
-    let mostRecent = T.pack . toUnrootedFilePath . takeFileName $ NEL.head stfs'
+    let mostRecent = T.pack . takeFileName $ NEL.head stfs'
     warn ss . cleanStates_5 mostRecent $ langOf ss
   okay <- optionalPrompt ss $ cleanStates_2 n
   if not okay
@@ -50,4 +50,4 @@ cleanStates ss (fromIntegral -> n) = do
 
 -- | The result of @-Bl@.
 listStates :: IO ()
-listStates = getStateFiles >>= traverse_ (putTextLn . T.pack . toFilePath)
+listStates = getStateFiles >>= traverse_ (putTextLn . T.pack)

--- a/aura/lib/Aura/Commands/L.hs
+++ b/aura/lib/Aura/Commands/L.hs
@@ -24,7 +24,6 @@ import           RIO hiding (FilePath)
 import qualified RIO.NonEmpty as NEL
 import qualified RIO.Text as T
 import qualified RIO.Text.Partial as T
-import           System.Path (toFilePath)
 import           System.Process.Typed (proc, runProcess)
 
 ---
@@ -41,13 +40,13 @@ data LogEntry = LogEntry
 -- | Pipes the pacman log file through a @less@ session.
 viewLogFile :: RIO Env ()
 viewLogFile = do
-  pth <- asks (toFilePath . either id id . logPathOf . commonConfigOf . settings)
+  pth <- asks (either id id . logPathOf . commonConfigOf . settings)
   void . runProcess $ proc "less" [pth]
 
 -- | Print all lines in the log file which contain a given `Text`.
 searchLogFile :: Settings -> Text -> IO ()
 searchLogFile ss input = do
-  let pth = toFilePath . either id id . logPathOf $ commonConfigOf ss
+  let pth = either id id . logPathOf $ commonConfigOf ss
   logFile <- T.lines . decodeUtf8Lenient <$> readFileBinary pth
   traverse_ putTextLn $ searchLines input logFile
 
@@ -55,7 +54,7 @@ searchLogFile ss input = do
 logInfoOnPkg :: NonEmpty PkgName -> RIO Env ()
 logInfoOnPkg pkgs = do
   ss <- asks settings
-  let pth = toFilePath . either id id . logPathOf $ commonConfigOf ss
+  let pth = either id id . logPathOf $ commonConfigOf ss
   logFile <- Log . T.lines . decodeUtf8Lenient <$> readFileBinary pth
   let (bads, goods) = fmapEither (logLookup logFile) $ toList pkgs
   traverse_ (report red reportNotInLog_1) $ NEL.nonEmpty bads

--- a/aura/lib/Aura/Core.hs
+++ b/aura/lib/Aura/Core.hs
@@ -40,7 +40,6 @@ import           Control.Monad.Trans.Maybe
 import           Data.Bifunctor (bimap)
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
-import           Data.These (These(..))
 import           RIO hiding ((<>))
 import qualified RIO.ByteString as B
 import qualified RIO.List as L

--- a/aura/lib/Aura/Core.hs
+++ b/aura/lib/Aura/Core.hs
@@ -42,11 +42,11 @@ import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
 import           RIO hiding ((<>))
 import qualified RIO.ByteString as B
+import           RIO.Directory (doesFileExist)
 import qualified RIO.List as L
 import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
-import           System.Path.IO (doesFileExist)
 
 ---
 

--- a/aura/lib/Aura/Dependencies.hs
+++ b/aura/lib/Aura/Dependencies.hs
@@ -23,7 +23,6 @@ import           Aura.Languages
 import           Aura.Settings
 import           Aura.Types
 import           Aura.Utils
-import           Data.These (these)
 import           Data.Versions hiding (Lens')
 import           Lens.Micro
 import           RIO

--- a/aura/lib/Aura/Diff.hs
+++ b/aura/lib/Aura/Diff.hs
@@ -10,7 +10,6 @@ module Aura.Diff ( diff ) where
 
 import Aura.Settings
 import RIO
-import System.Path (Absolute, Path, toFilePath)
 import System.Process.Typed (proc, runProcess)
 
 ---
@@ -19,6 +18,8 @@ import System.Process.Typed (proc, runProcess)
 -- Output will be coloured unless colour is deactivated by
 -- `--color never` or by detection of a non-terminal output
 -- target.
-diff :: MonadIO m => Settings -> Path Absolute -> Path Absolute -> m ()
-diff ss f1 f2 = void . runProcess . proc "diff" $ c <> ["-u", toFilePath f1, toFilePath f2]
-  where c = bool ["--color"] [] $ shared ss (Colour Never)
+diff :: MonadIO m => Settings -> FilePath -> FilePath -> m ()
+diff ss f1 f2 = void . runProcess . proc "diff" $ c <> ["-u", f1, f2]
+  where
+    c :: [FilePath]
+    c = bool ["--color"] [] $ shared ss (Colour Never)

--- a/aura/lib/Aura/Install.hs
+++ b/aura/lib/Aura/Install.hs
@@ -43,7 +43,6 @@ import qualified RIO.Map as M
 import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import qualified RIO.Text as T
-import           System.Path (fromAbsoluteFilePath)
 
 ---
 
@@ -249,4 +248,4 @@ pkgbuildDiffs ps = asks settings >>= check
           let new = "/tmp/new.pb"
           writeFileBinary new . pkgbuild $ bPkgbuild p
           liftIO . warn ss $ reportPkgbuildDiffs_3 pn lang
-          diff ss (pkgbuildPath pn) $ fromAbsoluteFilePath new
+          diff ss (pkgbuildPath pn) new

--- a/aura/lib/Aura/Pkgbuild/Base.hs
+++ b/aura/lib/Aura/Pkgbuild/Base.hs
@@ -11,15 +11,16 @@ module Aura.Pkgbuild.Base
   ) where
 
 import           Aura.Types
+import           RIO
+import           RIO.FilePath
 import qualified RIO.Text as T
-import           System.Path
 
 ---
 
 -- | The default location: \/var\/cache\/aura\/pkgbuilds\/
-pkgbuildCache :: Path Absolute
-pkgbuildCache = fromAbsoluteFilePath "/var/cache/aura/pkgbuilds/"
+pkgbuildCache :: FilePath
+pkgbuildCache = "/var/cache/aura/pkgbuilds/"
 
 -- | The expected path to a stored PKGBUILD, given some package name.
-pkgbuildPath :: PkgName -> Path Absolute
-pkgbuildPath (PkgName p) = pkgbuildCache </> fromUnrootedFilePath (T.unpack p) <.> FileExt "pb"
+pkgbuildPath :: PkgName -> FilePath
+pkgbuildPath (PkgName p) = pkgbuildCache </> T.unpack p <.> "pb"

--- a/aura/lib/Aura/Pkgbuild/Editing.hs
+++ b/aura/lib/Aura/Pkgbuild/Editing.hs
@@ -13,9 +13,7 @@ import Aura.Languages
 import Aura.Settings
 import Aura.Types
 import RIO
-import RIO.Directory (setCurrentDirectory)
-import System.Path (toFilePath)
-import System.Path.IO (getCurrentDirectory, getTemporaryDirectory)
+import RIO.Directory
 import System.Process.Typed (proc, runProcess)
 
 ---
@@ -45,7 +43,7 @@ hotEdit ss b
           f = do
             here <- getCurrentDirectory
             tmp  <- getTemporaryDirectory
-            setCurrentDirectory $ toFilePath tmp
+            setCurrentDirectory tmp
             b' <- edit (runProcess . proc (editorOf ss) . (:[])) b
-            setCurrentDirectory $ toFilePath here
+            setCurrentDirectory here
             pure b'

--- a/aura/lib/Aura/Pkgbuild/Records.hs
+++ b/aura/lib/Aura/Pkgbuild/Records.hs
@@ -14,8 +14,7 @@ module Aura.Pkgbuild.Records
 import Aura.Pkgbuild.Base
 import Aura.Types
 import RIO
-import System.Path (toFilePath)
-import System.Path.IO (createDirectoryIfMissing, doesFileExist)
+import RIO.Directory
 
 ---
 
@@ -31,4 +30,4 @@ storePkgbuilds bs = do
   traverse_ (\p -> writePkgbuild (bName p) (bPkgbuild p)) bs
 
 writePkgbuild :: PkgName -> Pkgbuild -> IO ()
-writePkgbuild pn (Pkgbuild pb) = writeFileBinary (toFilePath $ pkgbuildPath pn) pb
+writePkgbuild pn (Pkgbuild pb) = writeFileBinary (pkgbuildPath pn) pb

--- a/aura/lib/Aura/Settings.hs
+++ b/aura/lib/Aura/Settings.hs
@@ -30,7 +30,6 @@ import           Network.HTTP.Client (Manager)
 import           RIO
 import qualified RIO.Set as S
 import qualified RIO.Text as T
-import           System.Path (Absolute, Path, fromAbsoluteFilePath, toFilePath)
 
 ---
 
@@ -49,16 +48,16 @@ instance Flagable Makepkg where
 -- Aura will react to them, but also pass them through to `pacman`
 -- calls if necessary.
 data CommonConfig = CommonConfig
-  { cachePathOf      :: !(Either (Path Absolute) (Path Absolute))
-  , configPathOf     :: !(Either (Path Absolute) (Path Absolute))
-  , logPathOf        :: !(Either (Path Absolute) (Path Absolute))
+  { cachePathOf      :: !(Either FilePath FilePath)
+  , configPathOf     :: !(Either FilePath FilePath)
+  , logPathOf        :: !(Either FilePath FilePath)
   , commonSwitchesOf :: !(Set CommonSwitch) } deriving (Show, Generic)
 
 instance Flagable CommonConfig where
   asFlag (CommonConfig cap cop lfp cs) =
-    either (const []) (\p -> ["--cachedir", T.pack $ toFilePath p]) cap
-    <> either (const []) (\p -> ["--config", T.pack $ toFilePath p]) cop
-    <> either (const []) (\p -> ["--logfile", T.pack $ toFilePath p]) lfp
+    either (const []) (\p -> ["--cachedir", T.pack p]) cap
+    <> either (const []) (\p -> ["--config", T.pack p]) cop
+    <> either (const []) (\p -> ["--logfile", T.pack p]) lfp
     <> asFlag cs
 
 -- | Yes/No-style switches that are common to both Aura and Pacman.
@@ -85,7 +84,7 @@ instance Flagable ColourMode where
 -- | Settings unique to the AUR package building process.
 data BuildConfig = BuildConfig
   { makepkgFlagsOf  :: !(Set Makepkg)
-  , buildPathOf     :: !(Path Absolute)
+  , buildPathOf     :: !FilePath
   , buildUserOf     :: !(Maybe User)
   , truncationOf    :: !Truncation  -- For `-As`
   , buildSwitchesOf :: !(Set BuildSwitch) } deriving (Show)
@@ -131,5 +130,5 @@ logFuncOfL :: Lens' Settings LogFunc
 logFuncOfL f s = (\lf -> s { logFuncOf = lf }) <$> f (logFuncOf s)
 
 -- | Unless otherwise specified, packages will be built within @/tmp@.
-defaultBuildDir :: Path Absolute
-defaultBuildDir = fromAbsoluteFilePath "/tmp"
+defaultBuildDir :: FilePath
+defaultBuildDir = "/tmp"

--- a/aura/lib/Aura/Shell.hs
+++ b/aura/lib/Aura/Shell.hs
@@ -13,7 +13,6 @@ import           RIO
 import qualified RIO.ByteString as B
 import qualified RIO.Map as M
 import qualified RIO.Text as T
-import           System.Path (Absolute, Path, toFilePath)
 import           System.Process.Typed (proc, runProcess)
 
 ---
@@ -50,8 +49,8 @@ getLocale :: Environment -> Text
 getLocale env = fromMaybe "C" . asum $ map (`M.lookup` env) ["LC_ALL", "LC_MESSAGES", "LANG"]
 
 -- | Mark some `Path` as being owned by a `User`.
-chown :: MonadIO m => User -> Path Absolute -> [String] -> m ()
-chown (User usr) pth args = void . runProcess $ proc "chown" (args <> [T.unpack usr, toFilePath pth])
+chown :: MonadIO m => User -> FilePath -> [String] -> m ()
+chown (User usr) pth args = void . runProcess $ proc "chown" (args <> [T.unpack usr, pth])
 
 -- | Hide the cursor in a terminal.
 hideCursor :: IO ()

--- a/aura/lib/Aura/Types.hs
+++ b/aura/lib/Aura/Types.hs
@@ -45,7 +45,6 @@ import           Data.Aeson (FromJSONKey, ToJSONKey)
 import           Data.Bitraversable
 import           Data.Text.Prettyprint.Doc hiding (list, space)
 import           Data.Text.Prettyprint.Doc.Render.Terminal
-import           Data.These (These(..))
 import           Data.Versions hiding (Traversal')
 import           Lens.Micro
 import           RIO hiding (try)

--- a/aura/lib/Aura/Utils.hs
+++ b/aura/lib/Aura/Utils.hs
@@ -21,6 +21,9 @@ module Aura.Utils
     -- * Compactable
   , fmapEither
   , traverseEither
+    -- * These
+  , These(..)
+  , these
     -- * Misc.
   , maybe'
   , groupsOf
@@ -28,8 +31,7 @@ module Aura.Utils
   , partNonEmpty
   ) where
 
-import           Data.Bifunctor (bimap)
-import           Data.These (These(..))
+import           Data.Bifunctor
 import           Network.HTTP.Client
 import           Network.HTTP.Types.Status (statusCode)
 import           RIO
@@ -115,3 +117,31 @@ fold1 = foldMap1 id
 -- | Partition a `NonEmpty` based on some function.
 partNonEmpty :: (a -> These b c) -> NonEmpty a -> These (NonEmpty b) (NonEmpty c)
 partNonEmpty f = foldMap1 (bimap pure pure . f)
+
+--------------------------------------------------------------------------------
+-- These
+
+data These a b = This a | That b | These a b
+
+instance (Semigroup a, Semigroup b) => Semigroup (These a b) where
+  This x <> This y = This (x <> y)
+  This x <> These z y = These (x <> z) y
+  This x <> That y = These x y
+
+  That x <> That y = That (x <> y)
+  That x <> This y = These y x
+  That x <> These y z = These y (x <> z)
+
+  These w x <> This y = These (w <> y) x
+  These w x <> That y = These w (x <> y)
+  These w x <> These y z = These (w <> y) (x <> z)
+
+instance Bifunctor These where
+  bimap f _ (This x)    = This (f x)
+  bimap _ g (That y)    = That (g y)
+  bimap f g (These x y) = These (f x) (g y)
+
+these :: (a -> t) -> (b -> t) -> (a -> b -> t) -> These a b -> t
+these f _ _ (This a)    = f a
+these _ g _ (That b)    = g b
+these _ _ h (These a b) = h a b

--- a/aura/test/Test.hs
+++ b/aura/test/Test.hs
@@ -8,8 +8,8 @@ import           Aura.Types
 import           Data.Versions
 import           RIO
 import qualified RIO.Map as M
+import           RIO.Partial
 -- import           Language.Bash.Pretty (prettyText)
-import           System.Path
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Text.Megaparsec
@@ -45,7 +45,7 @@ suite conf pb = testGroup "Unit Tests"
     ]
   , testGroup "Aura.Types"
     [ testCase "simplepkg"
-      $ simplepkg (PackagePath $ fromAbsoluteFilePath "/var/cache/pacman/pkg/linux-is-cool-3.2.14-1-x86_64.pkg.tar.xz")
+      $ simplepkg (fromJust $ packagePath "/var/cache/pacman/pkg/linux-is-cool-3.2.14-1-x86_64.pkg.tar.xz")
       @?= Just (SimplePkg "linux-is-cool" . Ideal $ SemVer 3 2 14 [[Digits 1]] [])
     , testCase "simplepkg'"
       $ simplepkg' "xchat 2.8.8-19" @?= Just (SimplePkg "xchat" . Ideal $ SemVer 2 8 8 [[Digits 19]] [])

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.6
+resolver: lts-15.8
 
 ghc-options: {"$locals": -fwrite-ide-info}
 
@@ -17,4 +17,3 @@ packages:
 extra-deps:
   - language-bash-0.9.0
   - paths-0.2.0.0
-  - witherable-class-0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,13 +2,6 @@ resolver: lts-15.8
 
 ghc-options: {"$locals": -fwrite-ide-info}
 
-flags:
-  these:
-    aeson: false
-    assoc: false
-    semigroupoids: false
-    QuickCheck: false
-
 packages:
   - aura/
   - aur/

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,4 +9,3 @@ packages:
 
 extra-deps:
   - language-bash-0.9.0
-  - paths-0.2.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,13 +11,6 @@ packages:
       sha256: 2ce9873423de0aa54f098f3f46daa7519697bd2e79cb63c6aedc054b0293061b
   original:
     hackage: language-bash-0.9.0
-- completed:
-    hackage: paths-0.2.0.0@sha256:b550399f0d1181a00221931255c48d72d6eaa8301056afcc9f96288c71aab664,2629
-    pantry-tree:
-      size: 732
-      sha256: 775674b5c4b1431aa855b1966abbd59d64da87e8f05fb9bb0d782baca10a470d
-  original:
-    hackage: paths-0.2.0.0
 snapshots:
 - completed:
     size: 492015

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,16 +18,9 @@ packages:
       sha256: 775674b5c4b1431aa855b1966abbd59d64da87e8f05fb9bb0d782baca10a470d
   original:
     hackage: paths-0.2.0.0
-- completed:
-    hackage: witherable-class-0@sha256:91f05518f9f4af5b02424f13ee7dcdab5d6618e01346aa2f388a72ff93e2e501,775
-    pantry-tree:
-      size: 277
-      sha256: e99696bf95da593a3892c7b9a28db09ffd139b4b1b313f32cec9d26979aa7ce2
-  original:
-    hackage: witherable-class-0
 snapshots:
 - completed:
-    size: 491387
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/6.yaml
-    sha256: 8d81505a6de861e167a58534ab62330afb75bfa108735c7db1204f7ef2a39d79
-  original: lts-15.6
+    size: 492015
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/8.yaml
+    sha256: 926bc3d70249dd0ba05277ff00943c0addb35b627cb641752669e7cf771310d0
+  original: lts-15.8


### PR DESCRIPTION
This is to further increase Aura's "agility" when it comes to long-term maintenance. Fewer deps means it'll be less likely for Aura to spontaneously break due to package set updates.