### PR TITLE
Reverse .gitinore to normal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.hi
 *.o
 *.prof
-#*.svg
+*.svg
 *.txt
 .cabal-sandbox
 .stack-work/*

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Aura has been translated by these generous people:
 | Spanish    | Alejandro Gómez and Sergio Conde                |
 | Swedish    | Fredrik Haikarainen and Daniel Beecham          |
 
-Aura's logo is thanks to Cristiano Vitorino (@cristianovitorino).
+Aura's logo is thanks to [Cristiano Vitorino](https://github.com/cristianovitorino).
 
 # The `aur` Haskell Library
 


### PR DESCRIPTION
- Reverse `.gitinore` to normal, unhashing the `SVG` section.
- Alter logo's author credit in order to link to his GitHub profile.