### PR TITLE
Automatically supply aura.conf

### DIFF
--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### Added
 
 - Aura is now configurable via a conf file! Aura expects it at `/etc/aura.conf`.
+  If you install Aura via its AUR package, this file will be installed for you
+  automatically.
 
 ## 2.3.0 (2020-04-22)
 

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               aura
-version:            2.3.0
+version:            2.4.0
 synopsis:           A secure package manager for Arch Linux and the AUR.
 description:
   Aura is a package manager for Arch Linux. It connects to both the

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -20,6 +20,7 @@ extra-source-files:
   README.md
   CHANGELOG.md
   doc/aura.8
+  doc/aura.conf
   doc/completions/bashcompletion.sh
   doc/completions/_aura
   test/pacman.conf

--- a/aura/doc/aura.conf
+++ b/aura/doc/aura.conf
@@ -1,0 +1,60 @@
+# --- Aura Config --- #
+#
+# Template updated on: Mon 11 May 2020
+#
+# You can uncomment the various settings below in order to activate them.
+# Otherwise, Aura will use its internal defaults.
+
+# --- Language --- #
+# Aura can be used in different human languages. This field must be a 2-letter
+# language code, similar to those used in LOCALE. The available codes are:
+#
+# |------+------------|
+# | Code | Language   |
+# |------+------------|
+# | nl   | Dutch      |
+# | en   | English    |
+# | de   | German     |
+# | nb   | Norwegian  |
+# | sv   | Swedish    |
+# |------+------------|
+# | fr   | French     |
+# | it   | Italian    |
+# | pt   | Portuguese |
+# | es   | Spanish    |
+# |------+------------|
+# | hr   | Croatian   |
+# | pl   | Polish     |
+# | ru   | Russian    |
+# | sr   | Serbian    |
+# |------+------------|
+# | zh   | Chinese    |
+# | id   | Indonesian |
+# | ja   | Japanese   |
+# |------+------------|
+# | eo   | Esperanto  |
+# |------+------------|
+
+# Uncomment to activate:
+# language = en
+
+# --- Build Settings --- #
+# Aura runs via `sudo` but builds packages as the underlying non-root user.
+# Here, you can alter who that user is, and where packages are built.
+
+# Uncomment to activate:
+# user = YOU
+# buildpath = /tmp
+
+# --- PKGBUILD Analysis --- #
+# Aura automatically scans PKGBUILDs for malicious bash usage and other "bad
+# practices". Here, you can turn those scans off.
+
+# Uncomment to activate:
+# analyse = True
+
+# --- Misc. --- #
+
+# The editor to use with `--hotedit`.
+# Uncomment to activate:
+# editor = vi

--- a/aura/exec/Aura/Settings/Runtime.hs
+++ b/aura/exec/Aura/Settings/Runtime.hs
@@ -43,6 +43,7 @@ import qualified RIO.Map as M
 import qualified RIO.Set as S
 import qualified RIO.Text as T
 import           System.Environment (getEnvironment)
+import           Text.Printf
 
 ---
 
@@ -56,6 +57,7 @@ withEnv (Program op co bc lng ll) f = do
       igg = S.fromList $ op ^.. _Right . _AurSync . folded . _AurIgnoreGroup . folded
   confFile    <- getPacmanConf (either id id $ configPathOf co) >>= either throwM pure
   auraConf    <- auraConfig <$> getAuraConf defaultAuraConf
+  when (ll == LevelDebug) . printf "%s\n" $ show auraConf
   environment <- M.fromList . map (bimap T.pack T.pack) <$> getEnvironment
   manager     <- newManager tlsManagerSettings
   isTerm      <- hIsTerminalDevice stdout

--- a/aura/lib/Aura/Settings/External.hs
+++ b/aura/lib/Aura/Settings/External.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+
 -- |
 -- Module    : Aura.Settings.External
 -- Copyright : (c) Colin Woodbury, 2012 - 2020
@@ -38,8 +40,8 @@ data AuraConfig = AuraConfig
   , acEditor    :: Maybe FilePath
   , acUser      :: Maybe User
   , acBuildPath :: Maybe FilePath
-  , acAnalyse   :: Maybe BuildSwitch
-  }
+  , acAnalyse   :: Maybe BuildSwitch }
+  deriving stock (Show)
 
 defaultAuraConf :: FilePath
 defaultAuraConf = "/etc/aura.conf"

--- a/aura/lib/Aura/Settings/External.hs
+++ b/aura/lib/Aura/Settings/External.hs
@@ -58,7 +58,7 @@ auraConfig (Config m) = AuraConfig
   { acLang = one "language" >>= langFromLocale
   , acEditor = T.unpack <$> one "editor"
   , acUser = User <$> one "user"
-  , acBuildPath = T.unpack <$> one "build-path"
+  , acBuildPath = T.unpack <$> one "buildpath"
   , acAnalyse = one "analyse" >>= readMaybe . T.unpack >>= bool (Just NoPkgbuildCheck) Nothing
   }
   where


### PR DESCRIPTION
Instead of having Aura do it itself, the `aura.conf` will be installed as part of the AUR package installation process.