### PR TITLE
Restoring --allsource

### DIFF
--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -12,6 +12,7 @@
 module Aura.Build
   ( installPkgFiles
   , buildPackages
+  , srcPkgStore
   ) where
 
 import           Aura.Core

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -138,5 +138,7 @@ moveToCachePath ss p = copy $> fromJust (packagePath newName)
 
 -- | Moves a file to the aura src package cache and returns its location.
 moveToSourcePath :: FilePath -> IO FilePath
-moveToSourcePath p = renameFile p newName $> newName
+moveToSourcePath p = do
+  createDirectoryIfMissing True srcPkgStore
+  renameFile p newName $> newName
   where newName = srcPkgStore </> takeFileName p

--- a/aura/lib/Aura/Install.hs
+++ b/aura/lib/Aura/Install.hs
@@ -185,7 +185,7 @@ buildAndInstall bss = do
             Just pp | not (switch ss ForceBuilding) -> Right pp
             _                                       -> Left b
       built <- traverse buildPackages $ NEL.nonEmpty ps
-      traverse_ installPkgFiles $ built <> NEL.nonEmpty cached
+      traverse_ installPkgFiles $ fmap (<> cached) built >>= NEL.nonEmpty
       liftIO $ annotateDeps bs
 
 ------------

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -226,6 +226,14 @@ buildPackages_1 (bt . pnName -> p) = \case
     Dutch      -> "Pakket " <> p <> " aan het bouwen..."
     _          -> "Building " <> p <> "..."
 
+buildPackages_2 :: Language -> Doc AnsiStyle
+buildPackages_2 = \case
+  _ -> "'--allsource' detected. No actual installable packages will be built."
+
+buildPackages_3 :: FilePath -> Language -> Doc AnsiStyle
+buildPackages_3 fp = \case
+  _ -> "All .src.tar.gz files were built and copied to: " <> pretty fp
+
 buildFail_5 :: Language -> Doc AnsiStyle
 buildFail_5 = \case
     Japanese   -> "パッケージ作成に失敗しました。"


### PR DESCRIPTION
This functionality broke at some point, but has been complete restored with better user-facing messages.