### PR TITLE
Attempt to parse config from XDG user config dir

### DIFF
--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -97,7 +97,7 @@ library
     , network-uri       ^>=2.6
     , stm               ^>=2.5
     , time              >=1.8 && <1.10
-    , xdg-basedir       ==0.2.2
+    , xdg-basedir       ^>=0.2
 
 executable aura
   import:         commons, libexec

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -97,6 +97,7 @@ library
     , network-uri       ^>=2.6
     , stm               ^>=2.5
     , time              >=1.8 && <1.10
+    , xdg-basedir       ==0.2.2
 
 executable aura
   import:         commons, libexec

--- a/aura/exec/Aura/Settings/Runtime.hs
+++ b/aura/exec/Aura/Settings/Runtime.hs
@@ -55,7 +55,7 @@ withEnv (Program op co bc lng ll) f = do
   let ign = S.fromList $ op ^.. _Right . _AurSync . to toList . each . _AurIgnore . to toList . each
       igg = S.fromList $ op ^.. _Right . _AurSync . to toList . each . _AurIgnoreGroup . to toList . each
   confFile    <- getPacmanConf (either id id $ configPathOf co) >>= either throwM pure
-  auraConf    <- auraConfig <$> getAuraConf defaultAuraConf
+  auraConf    <- auraConfig <$> getAuraConf
   when (ll == LevelDebug) . printf "%s\n" $ show auraConf
   environment <- M.fromList . map (bimap T.pack T.pack) <$> getEnvironment
   manager     <- newManager tlsManagerSettings

--- a/aura/lib/Aura/Settings/External.hs
+++ b/aura/lib/Aura/Settings/External.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase   #-}
 
 -- |
 -- Module    : Aura.Settings.External
@@ -63,11 +64,9 @@ getAuraConfFrom path = do
       pure . hush $ parse config "aura config" file
 
 getAuraConf :: IO Config
-getAuraConf = do
-  userCfg <- getAuraConfFrom =<< userAuraConfPath
-  case userCfg of
-    (Just x) -> pure x
-    Nothing -> fromMaybe (Config M.empty) <$> getAuraConfFrom systemAuraConfPath
+getAuraConf = userAuraConfPath >>= getAuraConfFrom >>= \case
+  Just x -> pure x
+  Nothing -> fromMaybe (Config M.empty) <$> getAuraConfFrom systemAuraConfPath
 
 auraConfig :: Config -> AuraConfig
 auraConfig (Config m) = AuraConfig

--- a/aura/lib/Aura/Settings/External.hs
+++ b/aura/lib/Aura/Settings/External.hs
@@ -47,7 +47,7 @@ data AuraConfig = AuraConfig
   deriving stock (Show)
 
 userAuraConfPath :: IO FilePath
-userAuraConfPath = getUserConfigFile "aura" "config"
+userAuraConfPath = getUserConfigFile "aura" "aura.conf"
 
 systemAuraConfPath :: FilePath
 systemAuraConfPath = "/etc/aura.conf"


### PR DESCRIPTION
Hi! I'm the dude from Reddit. No Index yet, so here's a PR. :wink: 

The intention of this PR is to change the current Aura config behaviour from `try system | default` to `try user | try system | default`. The user config location is determined via [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), which is great for those of us who like to obsessively manage their [dotfiles](https://github.com/SamHH/dotfiles). A new dependency [xdg-basedir](https://github.com/sindresorhus/xdg-basedir) has been added for this purpose. A typical system's XDG config location would be `~/.config/aura/config`.

A behaviour I've observed, I think due to how the parsing works, is that an empty config file will be passed over, meaning that an empty user config will result in the `getAuraConf` function continuing onwards towards the system config. I'm unsure if this is desired behaviour.

I did consider creating a list of config locations and then trying them one by one, which'd be more extensible, but the last time I tried to utilise `Alternative` with `IO Maybe` it wasn't nearly as pleasant as just chaining a bunch of `<|>` together... don't know if it'd be feasible.

Not worked with Haskell professionally yet so let me know anything that needs changing or could be improved, however minor. Speaking of which, I'm unclear on best practices for dependency version ranges in Haskell, particularly for something that's 0.x. At the moment I've just pinned to `0.2.2` for stability.

Cheers!