### PR TITLE
+ Escaping

### DIFF
--- a/aur/CHANGELOG.md
+++ b/aur/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 7.0.4 (2020-09-11)
 
 - Escape `+` that can occasionally appear in package names.
 

--- a/aur/CHANGELOG.md
+++ b/aur/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Escape `+` that can occasionally appear in package names.
+
 ## 7.0.3 (2020-05-27)
 
 - Bumped `http-client` bounds.

--- a/aur/aur.cabal
+++ b/aur/aur.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               aur
-version:            7.0.3
+version:            7.0.4
 synopsis:           Access metadata from the Arch Linux User Repository.
 description:
   Access package information from Arch Linux's AUR via its RPC interface. The

--- a/aur/lib/Linux/Arch/Aur.hs
+++ b/aur/lib/Linux/Arch/Aur.hs
@@ -123,7 +123,11 @@ info :: Manager -> [Text] -> IO (Either AurError [AurInfo])
 info m ps = work m url
   where
     url = "https://aur.archlinux.org/rpc?v=5&type=info&" <> as
-    as = T.unpack . T.intercalate "&" $ map ("arg%5B%5D=" <>) ps
+    as = T.unpack . T.intercalate "&" $ map (\p -> "arg%5B%5D=" <> T.concatMap escape p) ps
+
+escape :: Char -> Text
+escape '+' = "%2B"
+escape c   = T.singleton c
 
 -- | Perform a @search@ call on a package name or description text.
 -- Will fail with a `Left` if there was a connection/decoding error.

--- a/aur/tests/Test.hs
+++ b/aur/tests/Test.hs
@@ -18,7 +18,7 @@ suite m = testGroup "RPC Calls"
   ]
 
 infoTest :: Manager -> Assertion
-infoTest m = info m ["aura", "aura-bin"] >>= \x -> (length <$> x) @?= Right 2
+infoTest m = info m ["aura", "aura-bin", "libc++"] >>= \x -> (length <$> x) @?= Right 3
 
 infoTest' :: Manager -> Assertion
 infoTest' m = info m ["aura1234567"] >>= \x -> (null <$> x) @?= Right True

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -51,7 +51,7 @@ common commons
 common libexec
   build-depends:
     , aeson                        >=1.2 && <1.6
-    , aur                          ^>=7.0
+    , aur                          ^>=7.0.4
     , http-client                  >=0.5 && <0.8
     , prettyprinter                >=1.2 && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.12
+resolver: lts-16.13
 
 ghc-options:
   $everything: -split-sections

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532377
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/12.yaml
-    sha256: f914cfa23fef85bdf895e300a8234d9d0edc2dbec67f4bc9c53f85867c50eab6
-  original: lts-16.12
+    size: 532381
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/13.yaml
+    sha256: 6ee17f7996e5bc75ae4406250841f1362ad4196418a4d90a0615ff4f26ac98df
+  original: lts-16.13


### PR DESCRIPTION
Previously, official packages with `+` in their name would be handled correctly, but it seems that similar AUR packages never were. This PR fixes the disparity.