### PR TITLE
Wide Search

### DIFF
--- a/aur/CHANGELOG.md
+++ b/aur/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### Added
+
+- `Ord` and `Hashable` instances for `AurInfo`.
+
 ## 7.0.4 (2020-09-11)
 
 - Escape `+` that can occasionally appear in package names.

--- a/aur/aur.cabal
+++ b/aur/aur.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               aur
-version:            7.0.4
+version:            7.0.5
 synopsis:           Access metadata from the Arch Linux User Repository.
 description:
   Access package information from Arch Linux's AUR via its RPC interface. The
@@ -38,6 +38,7 @@ library
   build-depends:
     , aeson       >=0.9  && <1.6
     , bytestring
+    , hashable    >= 1.2
     , http-types  ^>=0.12
     , text        ^>=1.2
 

--- a/aur/lib/Linux/Arch/Aur.hs
+++ b/aur/lib/Linux/Arch/Aur.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
@@ -21,8 +23,10 @@ module Linux.Arch.Aur
 import           Control.Applicative ((<|>))
 import           Data.Aeson
 import           Data.ByteString (ByteString)
+import           Data.Hashable (Hashable)
 import           Data.Text (Text)
 import qualified Data.Text as T
+import           GHC.Generics (Generic)
 import           Network.HTTP.Client
 import           Network.HTTP.Types.Status
 
@@ -64,7 +68,8 @@ data AurInfo = AurInfo
   , conflictsOf      :: [Text]
   , providesOf       :: [Text]
   , licenseOf        :: [Text]
-  , keywordsOf       :: [Text] } deriving (Eq,Show)
+  , keywordsOf       :: [Text]}
+  deriving (Eq, Ord, Show, Generic, Hashable)
 
 instance FromJSON AurInfo where
     parseJSON = withObject "AurInfo" $ \v -> AurInfo

--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## Unreleased
 
+#### Changed
+
+- *Breaking:* `-As` and `-Ai` will yield an exit code of `1` if no results were
+  found. This matches `pacman`.
+
 #### Added
 
 - `--nocheck` will be passed down to `makepkg` to avoid calling the `check()`
   function during the build process. [#647]
 - `--hotedit` now has a short variant: `-e`. [#643]
+- `-Ars <term>` or `-As <term> --reposearch` can be used to yield results from
+  both the AUR and official repos at the same time. [#644]
 
 #### Fixed
 
@@ -18,6 +25,7 @@
 [#636]: https://github.com/fosskers/aura/issues/636
 [#642]: https://github.com/fosskers/aura/issues/642
 [#639]: https://github.com/fosskers/aura/issues/639
+[#644]: https://github.com/fosskers/aura/issues/644
 
 ## 3.1.9 (2020-09-11)
 

--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - *Breaking:* `-As` and `-Ai` will yield an exit code of `1` if no results were
   found. This matches `pacman`.
+- `-As` now accepts multiple search terms to narrow in on specific packages.
 
 #### Added
 

--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -12,8 +12,8 @@
 - `--nocheck` will be passed down to `makepkg` to avoid calling the `check()`
   function during the build process. [#647]
 - `--hotedit` now has a short variant: `-e`. [#643]
-- `-Ars <term>` or `-As <term> --reposearch` can be used to yield results from
-  both the AUR and official repos at the same time. [#644]
+- `-Ars <term>` or `-As <term> --both` can be used to yield results from both
+  the AUR and official repos at the same time. [#644]
 
 #### Fixed
 

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -51,7 +51,7 @@ common commons
 common libexec
   build-depends:
     , aeson                        >=1.2 && <1.6
-    , aur                          ^>=7.0.4
+    , aur                          ^>=7.0.5
     , http-client                  >=0.5 && <0.8
     , prettyprinter                >=1.2 && <1.8
     , prettyprinter-ansi-terminal  ^>=1.1

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -118,11 +118,13 @@ dependencies will only show uncoloured package names.
 Search the AUR via a word only (no regex). Results are sorted by vote.
 Suboptions:
 .RS 4
-\fI\-\-abc\fR    : Sorts results alphabetically.
+\fI\-\-abc\fR      : Sorts results alphabetically.
 .P
-\fI\-\-head\=n\fR : Only show the first n results. Default n = 10
+\fI\-\-head\=n\fR   : Only show the first n results. Default n = 10
 .P
-\fI\-\-tail\=n\fR : Only show the last n results.  Default n = 10
+\fI\-\-tail\=n\fR   : Only show the last n results.  Default n = 10
+.P
+\fI\-r\fR, \fI\-\-both\fR : Show results from the official repos as well.
 .RE
 .RE
 .P

--- a/aura/exec/Aura/Commands/A.hs
+++ b/aura/exec/Aura/Commands/A.hs
@@ -33,6 +33,7 @@ import           Aura.Settings
 import           Aura.State (saveState)
 import           Aura.Types
 import           Aura.Utils
+import           Control.Scheduler (Comp(..), traverseConcurrently)
 import           Data.Aeson
 import           Data.Text.Prettyprint.Doc
 import           Data.Text.Prettyprint.Doc.Render.Terminal
@@ -151,7 +152,7 @@ aurPkgSearch :: NonEmpty Text -> RIO Env ()
 aurPkgSearch (NEL.map T.toLower -> terms) = do
   ss <- asks settings
   db <- S.map (pnName . spName) <$> liftIO (foreignPackages $ envOf ss)
-  infoSet <- HS.filter matched . HS.fromList . fold <$> traverse aurSearch terms
+  infoSet <- HS.filter matched . HS.fromList . fold <$> traverseConcurrently Par' aurSearch terms
   when (null infoSet) $ throwM Silent
   let sorted = sortAurInfo ss $ HS.toList infoSet
       truncated = map (\ai -> (ai, aurNameOf ai `S.member` db)) $ trunc ss sorted

--- a/aura/exec/Aura/Commands/A.hs
+++ b/aura/exec/Aura/Commands/A.hs
@@ -119,7 +119,10 @@ develPkgCheck = asks settings >>= \ss ->
 
 -- | The result of @-Ai@.
 aurPkgInfo :: NonEmpty PkgName -> RIO Env ()
-aurPkgInfo = aurInfo >=> traverse_ displayAurPkgInfo
+aurPkgInfo ps = do
+  res <- aurInfo ps
+  when (null res) $ throwM (Failure $ FailMsg packageNotFound_1)
+  traverse_ displayAurPkgInfo res
 
 displayAurPkgInfo :: AurInfo -> RIO Env ()
 displayAurPkgInfo ai = asks settings >>= \ss -> putTextLn $ renderAurPkgInfo ss ai <> "\n"

--- a/aura/exec/Aura/Commands/A.hs
+++ b/aura/exec/Aura/Commands/A.hs
@@ -152,6 +152,7 @@ aurPkgSearch regex = do
             Tail n -> reverse . take (fromIntegral n) . reverse
   results <- fmap (\x -> (x, aurNameOf x `S.member` db)) . t
             <$> aurSearch regex
+  when (null results) $ throwM Silent
   traverse_ (putTextLn . renderSearch ss regex) results
 
 renderSearch :: Settings -> Text -> (AurInfo, Bool) -> Text

--- a/aura/exec/Aura/Flags.hs
+++ b/aura/exec/Aura/Flags.hs
@@ -243,7 +243,7 @@ data AurOp
   = AurDeps     !(NonEmpty PkgName)
   | AurInfo     !(NonEmpty PkgName)
   | AurPkgbuild !(NonEmpty PkgName)
-  | AurSearch   !Text
+  | AurSearch   !(NonEmpty Text)
   | AurUpgrade  !(Set PkgName)
   | AurJson     !(NonEmpty PkgName)
   | AurTarball  !(NonEmpty PkgName)
@@ -318,7 +318,7 @@ aursync = bigA *>
         ds      = AurDeps <$> (flag' () (long "deps" <> short 'd' <> hidden <> help "View dependencies of an AUR package.") *> somePkgs')
         ainfo   = AurInfo <$> (flag' () (long "info" <> short 'i' <> hidden <> help "View AUR package information.") *> somePkgs')
         pkgb    = AurPkgbuild <$> (flag' () (long "pkgbuild" <> short 'p' <> hidden <> help "View an AUR package's PKGBUILD file.") *> somePkgs')
-        search  = AurSearch <$> strOption (long "search" <> short 's' <> metavar "STRING" <> hidden <> help "Search the AUR via a search string.")
+        search  = AurSearch <$> (flag' () (long "search" <> short 's' <> hidden <> help "Search the AUR via a search string.") *> someArgs')
         upgrade = AurUpgrade <$> (flag' () (long "sysupgrade" <> short 'u' <> hidden <> help "Upgrade all installed AUR packages.") *> fmap (S.map PkgName) manyArgs')
         aur     = AurJson <$> (flag' () (long "json" <> hidden <> help "Retrieve package JSON straight from the AUR.") *> somePkgs')
         tarball = AurTarball <$> (flag' () (long "downloadonly" <> short 'w' <> hidden <> help "Download a package tarball.") *> somePkgs')

--- a/aura/exec/Aura/Flags.hs
+++ b/aura/exec/Aura/Flags.hs
@@ -328,7 +328,7 @@ aursync = bigA *>
         igg  = AurIgnoreGroup . S.fromList . map PkgGroup . T.split (== ',')
           <$> strOption (long "ignoregroup" <> metavar "PKG(,PKG,...)" <> hidden <> help "Ignore packages from the given groups.")
         y    = flag' AurRepoSync (short 'y' <> hidden <> help "Do an -Sy before continuing.")
-        wide = flag' AurWideSearch (short 'r' <> long "--reposearch" <> hidden <> help "With -s: Search the official repos as well.")
+        wide = flag' AurWideSearch (short 'r' <> long "both" <> hidden <> help "With -s: Search the official repos as well.")
 
 backups :: Parser AuraOp
 backups = bigB *> (Backup <$> optional mods)

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -55,7 +55,6 @@ import           Aura.Utils (nes)
 import           Options.Applicative (execParser)
 import           RIO
 import           RIO.FilePath
-import qualified RIO.NonEmpty as NEL
 import qualified RIO.Set as S
 import           System.Process.Typed (proc, runProcess)
 
@@ -116,9 +115,9 @@ execOpts ops = do
         Left (AurInfo ps)     -> A.aurPkgInfo ps
         Left (AurPkgbuild ps) -> A.displayPkgbuild ps
         Left (AurSearch s)
-          | not (S.member AurWideSearch sws) -> A.aurPkgSearch $ NEL.head s
+          | not (S.member AurWideSearch sws) -> A.aurPkgSearch s
           | otherwise -> do
-              aur <- try @(RIO Env) @Failure . A.aurPkgSearch $ NEL.head s
+              aur <- try @(RIO Env) @Failure $ A.aurPkgSearch s
               -- If the AUR lookup succeeded but the -S didn't, the exit code should still be success.
               let term = SyncSearch s :| []
               repo <- try @(RIO Env) @Failure $ p (Sync (Left term) S.empty, S.empty)

--- a/aura/exec/aura.hs
+++ b/aura/exec/aura.hs
@@ -113,7 +113,11 @@ execOpts ops = do
         Left (AurDeps ps)     -> A.displayPkgDeps ps
         Left (AurInfo ps)     -> A.aurPkgInfo ps
         Left (AurPkgbuild ps) -> A.displayPkgbuild ps
-        Left (AurSearch s)    -> A.aurPkgSearch s
+        Left (AurSearch s)    -> do
+          A.aurPkgSearch s
+          when (S.member AurWideSearch sws) $ do
+            let term = pure . SyncSearch $ pure s
+            p (Sync (Left term) S.empty, S.empty)
         Left (AurUpgrade ps)  -> bool (trueRoot . sudo) id (switch ss DryRun) $ A.upgradeAURPkgs ps
         Left (AurJson ps)     -> A.aurJson ps
         Left (AurTarball ps)  -> A.fetchTarball ps

--- a/aura/lib/Aura/Languages.hs
+++ b/aura/lib/Aura/Languages.hs
@@ -1273,6 +1273,10 @@ reportNotInLog_1 = \case
 -- Aura/AUR functions
 -------------------------------
 
+packageNotFound_1 :: Language -> Doc AnsiStyle
+packageNotFound_1 = \case
+  _ -> "No packages found."
+
 -- https://github.com/fosskers/aura/issues/498
 connectFailure_1 :: Language -> Doc AnsiStyle
 connectFailure_1 = \case

--- a/aura/lib/Aura/Packages/AUR.hs
+++ b/aura/lib/Aura/Packages/AUR.hs
@@ -17,6 +17,7 @@ module Aura.Packages.AUR
     -- * Single Querying
   , aurInfo
   , aurSearch
+  , sortAurInfo
     -- * Source Retrieval
   , clone
   , pkgUrl


### PR DESCRIPTION
This PR implements a subflag for `-As` that allows it to yield results from the official repos as well.

### TODO

- [x] Confirm exit code details
- [x] Update manpage
- [x] Update CHANGELOG
- [x] Allow multiple search terms for `-As`
