### PR TITLE
Mention `-Aw` in the manpage

### DIFF
--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -131,6 +131,11 @@ Suboptions:
 Upgrade all installed AUR packages. \fI\-Au\fR is \fI\-Su\fR for AUR packages.
 .RE
 .P
+\fB\-w\fR, \-\-downloadonly <package(s)>
+.RS 4
+Download a package tarball.
+.RE
+.P
 \fB\-x\fR, \-\-unsuppress
 .RS 4
 Unsuppress \fImakepkg\fR output during building. By default this output is


### PR DESCRIPTION
`-Aw` as a featured had been removed once, I believe once Aura switched to using `git` internally. Later this feature was added back, but its entry was left out of the manpage.

See #644 .