### PR TITLE
/tmp Permissions

### DIFF
--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Aura Changelog
 
+## 3.2.2 (2020-10-29)
+
+#### Fixed
+
+- A bug involving permissions on the `/tmp` directory. [#661]
+
+[#661]: https://github.com/fosskers/aura/issues/661
+
 ## 3.2.1 (2020-10-27)
 
 With this release, Aura has passed 2,000 commits. Thank you for your ongoing support!

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               aura
-version:            3.2.1
+version:            3.2.2
 synopsis:           A secure package manager for Arch Linux and the AUR.
 description:
   Aura is a package manager for Arch Linux. It connects to both the

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -141,14 +141,17 @@ createWritableIfMissing pth = do
     -- This is a migration strategy - it ensures that directories created with
     -- old versions of Aura automatically have their permissions fixed.
     then case pth of
-      "/var/cache/aura/vcs" -> void . runProcess . setStderr closed . setStdout closed $ proc "chmod" ["755", pth]
-      "/tmp" -> void . runProcess . setStderr closed . setStdout closed $ proc "chmod" ["1777", pth]
-      _ -> pure ()
+      "/var/cache/aura/vcs" -> setMode "755"
+      "/tmp"                -> setMode "1777"
+      _                     -> pure ()
     -- The library function `createDirectoryIfMissing` seems to obey umasks when
     -- creating directories, which can cause problem later during the build
     -- processes of git packages. By manually creating the directory with the
     -- expected permissions, we avoid this problem.
     else void . runProcess . setStderr closed . setStdout closed $ proc "mkdir" ["-p", "-m755", pth]
+  where
+    setMode :: String -> RIO Env ()
+    setMode mode = void . runProcess . setStderr closed . setStdout closed $ proc "chmod" [mode, pth]
 
 -- | A unique directory name (within the greater "parent" build dir) in which to
 -- copy sources and actually build a package.

--- a/aura/lib/Aura/Build.hs
+++ b/aura/lib/Aura/Build.hs
@@ -134,13 +134,16 @@ build' b = do
     removeDirectoryRecursive buildDir
   pure r
 
-createWritableIfMissing :: FilePath -> RIO e ()
+createWritableIfMissing :: FilePath -> RIO Env ()
 createWritableIfMissing pth = do
   exists <- doesDirectoryExist pth
   if exists
     -- This is a migration strategy - it ensures that directories created with
     -- old versions of Aura automatically have their permissions fixed.
-    then void . runProcess . setStderr closed . setStdout closed $ proc "chmod" ["755", pth]
+    then case pth of
+      "/var/cache/aura/vcs" -> void . runProcess . setStderr closed . setStdout closed $ proc "chmod" ["755", pth]
+      "/tmp" -> void . runProcess . setStderr closed . setStdout closed $ proc "chmod" ["1777", pth]
+      _ -> pure ()
     -- The library function `createDirectoryIfMissing` seems to obey umasks when
     -- creating directories, which can cause problem later during the build
     -- processes of git packages. By manually creating the directory with the


### PR DESCRIPTION
This PR fixed a bug involving permissions of the `/tmp` directory.
