### PR TITLE
Man pages

### DIFF
--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -3,9 +3,6 @@
 .
 .TH aura 8 "2020 June" "Aura" "Aura Manual"
 .
-.\" Disable hyphenation.
-.nh
-.
 .SH NAME
 aura \- A package manager for Arch Linux and the AUR.
 .

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -13,7 +13,6 @@ aura \- A package manager for Arch Linux and the AUR.
 \fIaura\fR <operation> [options] [package(s)]
 .
 .SH DESCRIPTION
-.P
 \fIaura\fR is a secure, multilingual package manager for Arch Linux written in
 Haskell. It connects to both the official Arch repositories and to the Arch User
 Repositories (AUR), allowing easy control of all packages on an Arch system.
@@ -21,7 +20,6 @@ Aura allows \fIall\fR pacman operations and provides \fInew\fR custom ones for
 dealing with AUR packages.
 .
 .SH OPERATIONS
-.P
 \fB\-A\fR, \-\-aursync [package(s)]
 .RS 4
 Perform actions involving the [A]UR. Default action installs packages from the
@@ -67,7 +65,6 @@ aura -Ap <package> | aura -P
 .RE
 .
 .SH AUR SYNC OPTIONS (\fI\-A\fR)
-.P
 \fB\-a\fR, \-\-delmakedeps
 .RS 4
 Uninstalls build dependencies that are no longer required after installing the
@@ -213,7 +210,6 @@ in the given location, instead of the default \fI/var/cache/aura/vcs/\fR.
 .RE
 .
 .SH GLOBAL PACKAGE STATE OPTIONS (\fI\-B\fR)
-.P
 \fB\-c\fR, \-\-clean <states-to-retain>
 .RS 4
 Saves a given number of the most recently saved package states and removes the
@@ -233,7 +229,6 @@ Show all saved package state filenames.
 .RE
 .
 .SH DOWNGRADE OPTIONS (\fI\-C\fR)
-.P
 \fB\-b\fR, \-\-backup\fR <path>
 .RS 4
 Backup the package cache to a given directory. The given directory must already
@@ -265,7 +260,6 @@ will be output as\-is.
 .RE
 .
 .SH LOGFILE OPTIONS (\fI\-L\fR)
-.P
 \fB\-i\fR, \-\-info <package(s)>
 .RS 4
 Displays install / upgrade history for a given package. Under the `Recent
@@ -281,7 +275,6 @@ actions performed on a package.
 .RE
 .
 .SH ORPHAN PACKAGE OPTIONS (\fI\-O\fR)
-.P
 \fB\-a\fR, \-\-adopt <package(s)>
 .RS 4
 Mark a package as being explicitly installed (i.e. it's not a dependency).
@@ -293,7 +286,6 @@ Uninstall all orphan packages.
 .RE
 .
 .SH ANALYSIS OPTIONS (\fI\-P\fR)
-.P
 \fB\-f\fR, \-\-file <path>
 .RS 4
 Analyse a given PKGBUILD.
@@ -309,7 +301,6 @@ Analyse the PKGBUILDs of all locally installed AUR packages.
 .RE
 .
 .SH PACMAN / AURA DUAL FUNCTIONALITY OPTIONS
-.P
 \-\-noconfirm
 .RS 4
 Never ask for any Aura or Pacman confirmation. Any time a prompt would
@@ -341,7 +332,6 @@ that match the given glob pattern.
 .RE
 .
 .SH EXPOSED MAKEPKG OPTIONS
-.P
 \-\-ignorearch
 .RS 4
 Ignores processor architecture when building packages.
@@ -365,7 +355,6 @@ Skip all PGP checks.
 .RE
 .
 .SH LANGUAGE OPTIONS
-.P
 Aura is available in multiple languages. As options, they can be used with
 either their English names or their real names written in their native
 characters. The available languages are, in option form:
@@ -405,7 +394,6 @@ characters. The available languages are, in option form:
 \-\-dutch, \-\-nederlands
 .
 .SH PRO TIPS
-.P
 1. If you build a package and then choose not to install it, the built package
 file will still be moved to the cache. You can then install it whenever you
 want with \fI\-C\fR.
@@ -429,22 +417,18 @@ Fish => function search
 .RE
 .
 .SH SEE ALSO
-.P
 \fBaura.conf(5)\fR, \fBpacman\fR(8), \fBpacman.conf\fR(5), \fBmakepkg\fR(8)
 .
 .SH BUGS
-.P
 It is not recommended to install non-AUR packages with pacman or aura. Aura will
 assume they are AUR packages during a \fI\-Au\fR and attempt to upgrade them. If
 a name collision occurs (that is, if there is a legitimate AUR package with the
 same name as the one you installed) previous installations could be overwritten.
 .
 .SH AUTHOR
-.P
 Colin Woodbury <colin@fosskers.ca>
 .
 .SH CONTRIBUTORS
-.P
 Chris Warrick
 .P
 Brayden Banks

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -399,30 +399,6 @@ want with \fI\-C\fR.
 .P
 3. When upgrading, use \fI\-Akua\fR instead of just \fI\-Au\fR.  This will
 remove make deps, as well as show PKGBUILD diffs before building.
-.P
-4. If you want to search both the Repos and the AUR at the same time, you can
-use the following shell functions:
-.
-.RS
-.
-.TP
-.B Bash
-.EX
-function search() {
-    aura -Ss $1 && aura -As $1
-}
-.EE
-.
-.TP
-.B Fish
-.EX
-function search
-    aura -Ss $argv
-    aura -As $argv
-end
-.EE
-.
-.RE
 .
 .SH SEE ALSO
 \fBaura.conf(5)\fR, \fBpacman\fR(8), \fBpacman.conf\fR(5), \fBmakepkg\fR(8)

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -4,7 +4,7 @@
 .TH aura 8 "2021 January" "Aura" "Aura Manual"
 .
 .SH NAME
-aura \- A package manager for Arch Linux and the AUR.
+aura \- package manager utility and AUR helper
 .
 .SH SYNOPSIS
 \fIaura\fR <operation> [options] [package(s)]

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -402,15 +402,26 @@ remove make deps, as well as show PKGBUILD diffs before building.
 .P
 4. If you want to search both the Repos and the AUR at the same time, you can
 use the following shell functions:
-.RS 4
-Bash => function search() {
-          aura -Ss $1 && aura -As $1
-        }
-
-Fish => function search
-          aura -Ss $argv
-          aura -As $argv
-        end
+.
+.RS
+.
+.TP
+.B Bash
+.EX
+function search() {
+    aura -Ss $1 && aura -As $1
+}
+.EE
+.
+.TP
+.B Fish
+.EX
+function search
+    aura -Ss $argv
+    aura -As $argv
+end
+.EE
+.
 .RE
 .
 .SH SEE ALSO

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -1,17 +1,17 @@
 .\" Man page for `aura`
 .\" Written by Colin Woodbury <colin@fosskers.ca>
-
+.
 .TH aura 8 "2020 June" "Aura" "Aura Manual"
-
+.
 .\" Disable hyphenation.
 .nh
-
+.
 .SH NAME
 aura \- A package manager for Arch Linux and the AUR.
-
+.
 .SH SYNOPSIS
 \fIaura\fR <operation> [options] [package(s)]
-
+.
 .SH DESCRIPTION
 .P
 \fIaura\fR is a secure, multilingual package manager for Arch Linux written in
@@ -19,7 +19,7 @@ Haskell. It connects to both the official Arch repositories and to the Arch User
 Repositories (AUR), allowing easy control of all packages on an Arch system.
 Aura allows \fIall\fR pacman operations and provides \fInew\fR custom ones for
 dealing with AUR packages.
-
+.
 .SH OPERATIONS
 .P
 \fB\-A\fR, \-\-aursync [package(s)]
@@ -65,7 +65,7 @@ any package on the AUR, try the following:
 .RS 4
 aura -Ap <package> | aura -P
 .RE
-
+.
 .SH AUR SYNC OPTIONS (\fI\-A\fR)
 .P
 \fB\-a\fR, \-\-delmakedeps
@@ -211,7 +211,7 @@ use-case.
 Save the cloned sources of VCS packages (i.e. those that end in \fI*-git\fR, etc.)
 in the given location, instead of the default \fI/var/cache/aura/vcs/\fR.
 .RE
-
+.
 .SH GLOBAL PACKAGE STATE OPTIONS (\fI\-B\fR)
 .P
 \fB\-c\fR, \-\-clean <states-to-retain>
@@ -231,7 +231,7 @@ the time.
 .RS 4
 Show all saved package state filenames.
 .RE
-
+.
 .SH DOWNGRADE OPTIONS (\fI\-C\fR)
 .P
 \fB\-b\fR, \-\-backup\fR <path>
@@ -263,7 +263,7 @@ Remove only those package files which are not saved in a package record (a la \f
 Search the package cache via a regex. Any package name that matches the regex
 will be output as\-is.
 .RE
-
+.
 .SH LOGFILE OPTIONS (\fI\-L\fR)
 .P
 \fB\-i\fR, \-\-info <package(s)>
@@ -279,7 +279,7 @@ be printed.
 Search the pacman log file via a regex. Useful for singling out any and all
 actions performed on a package.
 .RE
-
+.
 .SH ORPHAN PACKAGE OPTIONS (\fI\-O\fR)
 .P
 \fB\-a\fR, \-\-adopt <package(s)>
@@ -291,6 +291,7 @@ Mark a package as being explicitly installed (i.e. it's not a dependency).
 .RS 4
 Uninstall all orphan packages.
 .RE
+.
 .SH ANALYSIS OPTIONS (\fI\-P\fR)
 .P
 \fB\-f\fR, \-\-file <path>
@@ -306,7 +307,7 @@ Analyse a PKGBUILD found in the specified directory.
 .RS 4
 Analyse the PKGBUILDs of all locally installed AUR packages.
 .RE
-
+.
 .SH PACMAN / AURA DUAL FUNCTIONALITY OPTIONS
 .P
 \-\-noconfirm
@@ -338,7 +339,7 @@ will attempt to colour text if the terminal allows it. Otherwise, you can pass
 If there are file conflicts during installation, overwrite conflicting files
 that match the given glob pattern.
 .RE
-
+.
 .SH EXPOSED MAKEPKG OPTIONS
 .P
 \-\-ignorearch
@@ -362,7 +363,7 @@ Skip package source integrity checks.
 .RS 4
 Skip all PGP checks.
 .RE
-
+.
 .SH LANGUAGE OPTIONS
 .P
 Aura is available in multiple languages. As options, they can be used with
@@ -402,7 +403,7 @@ characters. The available languages are, in option form:
 \-\-esperanto
 .P
 \-\-dutch, \-\-nederlands
-
+.
 .SH PRO TIPS
 .P
 1. If you build a package and then choose not to install it, the built package
@@ -426,22 +427,22 @@ Fish => function search
           aura -As $argv
         end
 .RE
-
+.
 .SH SEE ALSO
 .P
 \fBaura.conf(5)\fR, \fBpacman\fR(8), \fBpacman.conf\fR(5), \fBmakepkg\fR(8)
-
+.
 .SH BUGS
 .P
 It is not recommended to install non-AUR packages with pacman or aura. Aura will
 assume they are AUR packages during a \fI\-Au\fR and attempt to upgrade them. If
 a name collision occurs (that is, if there is a legitimate AUR package with the
 same name as the one you installed) previous installations could be overwritten.
-
+.
 .SH AUTHOR
 .P
 Colin Woodbury <colin@fosskers.ca>
-
+.
 .SH CONTRIBUTORS
 .P
 Chris Warrick
@@ -457,7 +458,7 @@ Jimmy Brisson
 Kyle Raftogianis
 .P
 Nicholas Clarke
-
+.
 .SH TRANSLATORS
 .P
 (   Polish   ) Chris Warrick and Michał Kurek

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -1,3 +1,4 @@
+'\" t
 .\" Man page for `aura`
 .\" Written by Colin Woodbury <colin@fosskers.ca>
 .
@@ -22,12 +23,15 @@
 ..
 .
 .SH NAME
+.
 aura \- package manager utility and AUR helper
 .
 .SH SYNOPSIS
+.
 \fIaura\fR <operation> [options] [package(s)]
 .
 .SH DESCRIPTION
+.
 \fIaura\fR is a secure, multilingual package manager for Arch Linux written in
 Haskell. It connects to both the official Arch repositories and to the Arch User
 Repositories (AUR), allowing easy control of all packages on an Arch system.
@@ -35,171 +39,186 @@ Aura allows \fIall\fR pacman operations and provides \fInew\fR custom ones for
 dealing with AUR packages.
 .
 .SH OPERATIONS
+.
+.TP
 \fB\-A\fR, \-\-aursync [package(s)]
-.RS 4
+.
 Perform actions involving the [A]UR. Default action installs packages from the
 AUR. During building, makepkg output is \fInot\fR shown by default. After
 building, the built \fI.pkg.tar.xz\fR file is moved to the package cache and
 installed from there. This allows for easy AUR package downgrading.
-.RE
-.P
+.
+.TP
 \fB\-B\fR, \-\-save
-.RS 4
+.
 Manage the saving and restoring of the global package state. Default action
 stores a record of all currently installed packages and their versions.
-.RE
-.P
+.
+.TP
 \fB\-C\fR, \-\-downgrade [package(s)]
-.RS 4
+.
 Perform actions involving the package [C]ache. Default action downgrades
 specified packages. This process is interactive, allowing the user to choose
 from any previous version they have available in the package cache.
-.RE
-.P
+.
+.TP
 \fB\-L\fR, \-\-viewlog
-.RS 4
+.
 Perform actions involving the pacman [L]ogfile.
 Default action opens the log for read-only viewing.
-.RE
-.P
+.
+.TP
 \fB\-O\fR, \-\-orphans [package(s)]
-.RS 4
+.
 Perform actions involving [O]rphan packages. Orphan packages are packages
 installed as dependencies, but are no longer required by any other package.
 Default action is to list the current orphans.
-.RE
-.P
+.
+.TP
 \fB\-P\fR, \-\-analysis <stdin>
-.RS 4
+.
 Perform security analysis of a [P]KGBUILD. Useful for package maintainers and
 sysadmins to verify the safety of the PKGBUILD files that they write. To test
 any package on the AUR, try the following:
-.P
-.RS 4
+.
+.RSAMPLE
 aura -Ap <package> | aura -P
-.RE
+.ERSAMPLE
 .
 .SH AUR SYNC OPTIONS (\fI\-A\fP)
+.
+.TP
 \fB\-a\fR, \-\-delmakedeps
-.RS 4
+.
 Uninstalls build dependencies that are no longer required after installing the
 main package. This prevents the creation of orphan packages. Also note that
 while the package itself will be uninstalled, its package file will remain in
 the cache.
-.RE
-.P
+.
+.TP
 \fB\-c\fR, \-\-clean
-.RS 4
-After a package's tarball has been built and copied to the package cache, delete
-its build directory immediately.
-.RE
-.P
+.
+After a package's tarball has been built and copied to the package cache,
+delete its build directory immediately.
+.
+.TP
 \fB\-d\fR, \-\-deps <package(s)>
-.RS 4
+.
 View all the dependencies of a package. This process is recursive for AUR
 packages, so all dependencies of dependencies (and so on) will also be shown.
 This can aid the pre-install package research process.
-.RE
-.P
+.
+.TP
 \fB\-i\fR, \-\-info <package(s)>
-.RS 4
+.
 View information about a package in the AUR.
-.RE
-.P
+.
+.TP
 \fB\-k\fR, \-\-diff
-.RS 4
+.
 Shows PKGBUILD diffs. When upgrading, using this option will compare the most
 and second-most recent PKGBUILDs and output changes in colour.
-.RE
-.P
+.
+.TP
 \fB\-p\fR, \-\-pkgbuild <package(s)>
-.RS 4
+.
 Outputs an AUR package's PKGBUILD. Use this before installing new packages to
 confirm that the build scripts aren't doing anything fishy.
-.RE
-.P
+.
+.TP
 \fB\-q\fR, \-\-quiet
-.RS 4
+.
 Display less information about certain aursync operations (this is useful when
 processing Aura's output in a script). In particular, search and view
 dependencies will only show uncoloured package names.
-.RE
-.P
+.
+.TP
 \fB\-s\fR, \-\-search <word>
-.RS 4
+.
 Search the AUR via a word only (no regex). Results are sorted by vote.
 Suboptions:
-.RS 4
-\fI\-\-abc\fR      : Sorts results alphabetically.
-.P
-\fI\-\-head\=n\fR   : Only show the first n results. Default n = 10
-.P
-\fI\-\-tail\=n\fR   : Only show the last n results.  Default n = 10
-.P
-\fI\-r\fR, \fI\-\-both\fR : Show results from the official repos as well.
+.
+.RS
+.
+.TP
+\fB\-\-abc\fR
+Sorts results alphabetically.
+.
+.TP
+\fB\-\-head\=n\fR
+Only show the first n results. Default n = 10.
+.
+.TP
+\fB\-\-tail\=n\fR
+Only show the last n results.  Default n = 10.
+.
+.TP
+\fB\-r\fR, \fB\-\-both\fR
+Show results from the official repos as well.
+.
 .RE
-.RE
-.P
+.
+.TP
 \fB\-u\fR, \-\-sysupgrade
-.RS 4
+.
 Upgrade all installed AUR packages. \fI\-Au\fR is \fI\-Su\fR for AUR packages.
-.RE
-.P
+.
+.TP
 \fB\-w\fR, \-\-downloadonly <package(s)>
-.RS 4
+.
 Download a package tarball.
-.RE
-.P
+.
+.TP
 \fB\-x\fR, \-\-unsuppress
-.RS 4
+.
 Unsuppress \fImakepkg\fR output during building. By default this output is
 suppressed for a more silent install. Note that when this option isn't used,
 \fImakepkg\fR output is actually collected and printed if any errors occur.
-.RE
-.P
+.
+.TP
 \fB\-\-json\fP <package(s)>
-.RS 4
+.
 Query the AUR RPC for package info as raw JSON. Good for debugging.
-.RE
-.P
+.
+.TP
 \fB\-\-build\fR <path>
-.RS 4
+.
 Specify build path when building AUR packages. Only the \fIfull\fR path of a
 pre-existing directory can be used. Example:
-.P
-.RS 4
+.
+.RSAMPLE
 aura -A foo --build=/full/path/to/build/location/
-.RE
-.RE
-.P
+.ERSAMPLE
+.
+.TP
 \fB\-\-builduser\fR <username>
-.RS 4
+.
 Specify the user to build packages as. This can be useful when logged in as
 root and a build user is available.
-.RE
-.P
+.
+.TP
 \fB\-\-devel\fR
-.RS 4
+.
 When ran with \fI\-Au\fR, adds all development packages to the queue of
 packages to upgrade. Devel packages are those pulled directly from online
 repositories, via git / mercurial / etc.
-.RE
-.P
+.
+.TP
 \fB\-\-dryrun\fR
-.RS 4
+.
 When ran with \fI\-A\fR or \fI\-Au\fR, update checks, PKGBUILD diffs, and
 dependency checks will be performed, but nothing will be built. Also usable
 with \fI\-M\fR.
-.RE
-.P
+.
+.TP
 \fB\-\-force\fR
-.RS 4
+.
 Always (re)build the specified packages. Usually Aura will not rebuild packages
 whose versions are already available in the local package cache.
-.RE
-.P
+.
+.TP
 \fB\-\-hotedit\fR
-.RS 4
+.
 Prompt the user before building to ask if they wish to view/edit the PKGBUILD,
 as well as any .install or .patch files. However, research into packages (and by
 extension, their PKGBUILDs) should be done by the user before any building
@@ -209,274 +228,264 @@ that, since aura is run through sudo, your local value of $EDITOR may not be
 preserved. Run as "sudo \fI\-E\fR aura -A --hotedit ..." to preserve your
 environment. To always allow environment variables to be passed, have a look at
 the \fIenv_reset\fR and \fIenv_keep\fR options in \fBsudoers\fR(5).
-.RE
-.P
+.
+.TP
 \fB\-\-skipdepcheck\fR
-.RS 4
+.
 Perform no dependency solving. Consider this when using \fI\-\-hotedit\fR to
 avoid building annoying dependencies that aren't necessary for your special
 use-case.
-.RE
-.P
+.
+.TP
 \fB\-\-vcspath\fP \fI<path>\fP
-.RS 4
+.
 Save the cloned sources of VCS packages (i.e. those that end in \fI*-git\fR, etc.)
 in the given location, instead of the default \fI/var/cache/aura/vcs/\fR.
-.RE
 .
 .SH GLOBAL PACKAGE STATE OPTIONS (\fI\-B\fP)
+.
+.TP
 \fB\-c\fR, \-\-clean <states-to-retain>
-.RS 4
+.
 Saves a given number of the most recently saved package states and removes the
 rest.
-.RE
-.P
+.
+.TP
 \fB\-r\fR, \-\-restore\fR
-.RS 4
+.
 Restores a record kept with \fI\-B\fR. Attempts to downgrade any packages that
 were upgraded since the chosen save. Will remove any that weren't installed at
 the time.
-.RE
-.P
+.
+.TP
 \fB\-l\fR, \-\-list\fR
-.RS 4
+.
 Show all saved package state filenames.
-.RE
 .
 .SH DOWNGRADE OPTIONS (\fI\-C\fP)
+.
+.TP
 \fB\-b\fR, \-\-backup <path>
-.RS 4
+.
 Backup the package cache to a given directory. The given directory must already
 exist. During copying, progress will be shown. If the copy takes too long, you
 may want to reduce the number of older versions of each package by using
 \fI\-Cc\fR.
-.RE
-.P
+.
+.TP
 \fB\-c\fR, \-\-clean <versions-to-retain>
-.RS 4
+.
 Saves a given number of package versions for each package and deletes the rest
 from the package cache. Count is made from the most recent version, so using:
-.RS 4
+.
+.RSAMPLE
 aura -Cc 3
-.RE
+.ERSAMPLE
+.
+.IP
 would save the three most recent versions of each package file.
 Giving the number 0 as an argument is identical to \fI\-Scc\fR.
-.RE
-.P
+.
+.TP
 \fB\-\-notsaved\fP
-.RS 4
+.
 Remove only those package files which are not saved in a package record (a la \fI\-B\fR).
-.RE
-.P
+.
+.TP
 \fB\-s\fR, \-\-search <regex>
-.RS 4
+.
 Search the package cache via a regex. Any package name that matches the regex
 will be output as\-is.
-.RE
 .
 .SH LOGFILE OPTIONS (\fI\-L\fP)
+.
+.TP
 \fB\-i\fR, \-\-info <package(s)>
-.RS 4
+.
 Displays install / upgrade history for a given package. Under the `Recent
 Actions` section, only the last five entries will be displayed. If there are
 less than five actions ever performed with the package, what is available will
 be printed.
-.RE
-.P
+.
+.TP
 \fB\-s\fR, \-\-search <regex>
-.RS 4
+.
 Search the pacman log file via a regex. Useful for singling out any and all
 actions performed on a package.
-.RE
 .
 .SH ORPHAN PACKAGE OPTIONS (\fI\-O\fP)
+.
+.TP
 \fB\-a\fR, \-\-adopt <package(s)>
-.RS 4
+.
 Mark a package as being explicitly installed (i.e. it's not a dependency).
-.RE
-.P
+.
+.TP
 \fB\-j\fR, \-\-abandon
-.RS 4
+.
 Uninstall all orphan packages.
-.RE
 .
 .SH ANALYSIS OPTIONS (\fI\-P\fP)
+.
+.TP
 \fB\-f\fR, \-\-file <path>
-.RS 4
+.
 Analyse a given PKGBUILD.
-.RE
+.
+.TP
 \fB\-d\fR, \-\-dir <path>
-.RS 4
+.
 Analyse a PKGBUILD found in the specified directory.
-.RE
-.P
+.
+.TP
 \fB\-a\fR, \-\-audit
-.RS 4
+.
 Analyse the PKGBUILDs of all locally installed AUR packages.
-.RE
 .
 .SH PACMAN / AURA DUAL FUNCTIONALITY OPTIONS
+.
+.TP
 \-\-noconfirm
-.RS 4
+.
 Never ask for any Aura or Pacman confirmation. Any time a prompt would
 appear, say before building or installation, it is assumed the user
 answered in whatever way would progress the program.
-.RE
-.P
+.
+.TP
 \-\-needed
-.RS 4
+.
 Don't rebuild/reinstall packages that are already up to date.
-.RE
-.P
+.
+.TP
 \-\-debug
-.RS 4
+.
 View some handy debugging information.
-.RE
-.P
+.
+.TP
 \-\-color [mode]
-.RS 4
+.
 Whether or not to colour output text. Without this flag, both Aura and Pacman
 will attempt to colour text if the terminal allows it. Otherwise, you can pass
 \fInever\fR or \fIalways\fR to be specific about your wants.
-.RE
-.P
+.
+.TP
 \-\-overwrite <glob>
-.RS 4
+.
 If there are file conflicts during installation, overwrite conflicting files
 that match the given glob pattern.
-.RE
 .
 .SH EXPOSED MAKEPKG OPTIONS
+.
+.TP
 \-\-ignorearch
-.RS 4
+.
 Ignores processor architecture when building packages.
-.RE
-.P
+.
+.TP
 \-\-allsource
-.RS 4
+.
 Creates a \fI.src\fR file containing all the downloaded sources (code, etc) and
 stores it at \fI/var/cache/aura/src/\fR. To change the location where sources
 are stored, use the \fI\-\-allsourcepath\fR flag.
-.RE
-.P
+.
+.TP
 \-\-skipinteg
-.RS 4
+.
 Skip package source integrity checks.
-.RE
-.P
+.
+.TP
 \-\-skippgpcheck
-.RS 4
+.
 Skip all PGP checks.
-.RE
 .
 .SH LANGUAGE OPTIONS
+.
 Aura is available in multiple languages. As options, they can be used with
 either their English names or their real names written in their native
 characters. The available languages are, in option form:
-.P
-\-\-english (default)
-.P
-\-\-japanese, \-\-日本語
-.P
-\-\-polish, \-\-polski
-.P
-\-\-croatian, \-\-hrvatski
-.P
-\-\-swedish, \-\-svenska
-.P
-\-\-german, \-\-deutsch
-.P
-\-\-spanish, \-\-español
-.P
-\-\-portuguese, \-\-português
-.P
-\-\-french, \-\-français
-.P
-\-\-russian, \-\-русский
-.P
-\-\-italian, \-\-italiano
-.P
-\-\-serbian, \-\-српски
-.P
-\-\-norwegian, \-\-norsk
-.P
-\-\-indonesian
-.P
-\-\-chinese, \-\-中文
-.P
-\-\-esperanto
-.P
-\-\-dutch, \-\-nederlands
+.
+.TS \" Tab-separated
+l l.
+\fB\-\-english\fP	(default)
+\fB\-\-japanese\fP	\fB\-\-日本語\fP
+\fB\-\-polish\fP	\fB\-\-polski\fP
+\fB\-\-croatian\fP	\fB\-\-hrvatski\fP
+\fB\-\-swedish\fP	\fB\-\-svenska\fP
+\fB\-\-german\fP	\fB\-\-deutsch\fP
+\fB\-\-spanish\fP	\fB\-\-español\fP
+\fB\-\-portuguese\fP	\fB\-\-português\fP
+\fB\-\-french\fP	\fB\-\-français\fP
+\fB\-\-russian\fP	\fB\-\-русский\fP
+\fB\-\-italian\fP	\fB\-\-italiano\fP
+\fB\-\-serbian\fP	\fB\-\-српски\fP
+\fB\-\-norwegian\fP	\fB\-\-norsk\fP
+\fB\-\-indonesian\fP
+\fB\-\-chinese\fP	\fB\-\-中文\fP
+\fB\-\-esperanto\fP
+\fB\-\-dutch\fP	\fB\-\-nederlands\fP
+.TE
 .
 .SH PRO TIPS
-1. If you build a package and then choose not to install it, the built package
+.
+.IP \(bu 2n
+If you build a package and then choose not to install it, the built package
 file will still be moved to the cache. You can then install it whenever you
 want with \fI\-C\fR.
-.P
-2. Research packages using \fI\-Ad\fR, \fI\-Ai\fR, and \fI\-Ap\fR!
-.P
-3. When upgrading, use \fI\-Akua\fR instead of just \fI\-Au\fR.  This will
+.
+.IP \(bu 2n
+Research packages using \fI\-Ad\fR, \fI\-Ai\fR, and \fI\-Ap\fR!
+.
+.IP \(bu 2n
+When upgrading, use \fI\-Akua\fR instead of just \fI\-Au\fR.  This will
 remove make deps, as well as show PKGBUILD diffs before building.
 .
 .SH SEE ALSO
+.
 \fBaura.conf(5)\fR, \fBpacman\fR(8), \fBpacman.conf\fR(5), \fBmakepkg\fR(8)
 .
 .SH BUGS
+.
 It is not recommended to install non-AUR packages with pacman or aura. Aura will
 assume they are AUR packages during a \fI\-Au\fR and attempt to upgrade them. If
 a name collision occurs (that is, if there is a legitimate AUR package with the
 same name as the one you installed) previous installations could be overwritten.
 .
 .SH AUTHOR
+.
 Colin Woodbury <colin@fosskers.ca>
 .
 .SH CONTRIBUTORS
+.
+.TS \" Tab-separated
+l .
 Chris Warrick
-.P
 Brayden Banks
-.P
 Denis Kasak
-.P
 Edwin Marshall
-.P
 Jimmy Brisson
-.P
 Kyle Raftogianis
-.P
 Nicholas Clarke
+.TE
 .
 .SH TRANSLATORS
-.P
-(   Polish   ) Chris Warrick and Michał Kurek
-.P
-(  Croatian  ) Denis Kasak and "stranac"
-.P
-(  Swedish   ) Fredrik Haikarainen and Daniel Beecham
-.P
-(   German   ) Lukas Niederbremer
-.P
-(  Spanish   ) Alejandro Gómez, Sergio Conde, and Max Ferrer
-.P
-( Portuguese ) Henry Kupty, Thiago Perrotta, and Wagner Amaral
-.P
-(   French   ) Ma Jiehong and Fabien Dubosson
-.P
-(  Russian   ) Kyrylo Silin and Alexey Kotlyarov
-.P
-(  Italian   ) Bob Valantin and Cristian Tentella
-.P
-(  Serbian   ) Filip Brcic
-.P
-( Norwegian  ) "chinatsun"
-.P
-( Indonesian ) "pak tua Greg"
-.P
-( Chinese    ) Kai Zhang
-.P
-( Japanese   ) Onoue Takuro
-.P
-( Esperanto  ) Zachary Matthews
-.P
-(   Dutch    ) Joris Blanken
-.P
-(  Turkish   ) Cihan Alkan
+.
+.TS \" Tab-separated
+c l .
+Polish	Chris Warrick and Michał Kurek
+Croatian	Denis Kasak and "stranac"
+Swedish	Fredrik Haikarainen and Daniel Beecham
+German	Lukas Niederbremer
+Spanish	Alejandro Gómez, Sergio Conde, and Max Ferrer
+Portuguese	Henry Kupty, Thiago Perrotta, and Wagner Amaral
+French	Ma Jiehong and Fabien Dubosson
+Russian	Kyrylo Silin and Alexey Kotlyarov
+Italian	Bob Valantin and Cristian Tentella
+Serbian	Filip Brcic
+Norwegian	"chinatsun"
+Indonesian	"pak tua Greg"
+Chinese	Kai Zhang
+Japanese	Onoue Takuro
+Esperanto	Zachary Matthews
+Dutch	Joris Blanken
+Turkish	Cihan Alkan
+.TE

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -3,6 +3,24 @@
 .
 .TH aura 8 "2021 January" "Aura" "Aura Manual"
 .
+.de SAMPLE      \" Indented example - on its own paragraph.
+.  P
+.  RS
+.  EX
+..
+.de ESAMPLE     \" End of Indented example.
+.  EE
+.  RE
+..
+.de RSAMPLE     \" Relative sample - even more indented example.
+.  RS
+.  SAMPLE
+..
+.de ERSAMPLE    \" End of Relative sample.
+.  ESAMPLE
+.  RE
+..
+.
 .SH NAME
 aura \- package manager utility and AUR helper
 .

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -22,261 +22,431 @@
 .  RE
 ..
 .
+.ds ellipsis \&.\|.\|.\&
+.\" Format repeatable parameter (1 or more) with ellipsis.
+.ds multi                 \fI\\$1\fP\fR\\ \\*[ellipsis]\fP
+.\" Format optional repeatable parameter (0 or more)
+.\" with ellipsis and square brackets.
+.ds multi-optional \fR[\fP\fI\\$1\fP\fR\\ \\*[ellipsis]]\fP
+.ds packages          \\*[multi          packages]
+.ds packages-optional \\*[multi-optional packages]
+.
 .SH NAME
 .
 aura \- package manager utility and AUR helper
 .
 .SH SYNOPSIS
 .
-\fIaura\fR <operation> [options] [package(s)]
+.SY aura
+.I OPERATION
+\*[multi-optional OPTIONS]
+\*[multi-optional targets]
+.YS
 .
 .SH DESCRIPTION
 .
-\fIaura\fR is a secure, multilingual package manager for Arch Linux written in
-Haskell. It connects to both the official Arch repositories and to the Arch User
-Repositories (AUR), allowing easy control of all packages on an Arch system.
-Aura allows \fIall\fR pacman operations and provides \fInew\fR custom ones for
-dealing with AUR packages.
+.B aura
+is a secure, multilingual package manager for Arch Linux written in Haskell.
+.
+It connects to both the official Arch repositories and to the
+Arch User Repositories (AUR),
+allowing easy control of all packages on an Arch system.
+.
+Aura allows
+.I all
+pacman operations and provides
+.I new
+custom ones for dealing with AUR packages.
 .
 .SH OPERATIONS
 .
 .TP
-\fB\-A\fR, \-\-aursync [package(s)]
+.BR \-A ", " \-\-aursync " \*[packages-optional]"
 .
-Perform actions involving the [A]UR. Default action installs packages from the
-AUR. During building, makepkg output is \fInot\fR shown by default. After
-building, the built \fI.pkg.tar.xz\fR file is moved to the package cache and
-installed from there. This allows for easy AUR package downgrading.
+Perform actions involving the
+.BR A UR.
 .
-.TP
-\fB\-B\fR, \-\-save
+Default action installs packages from the AUR.
 .
-Manage the saving and restoring of the global package state. Default action
-stores a record of all currently installed packages and their versions.
+.IP
+During building, makepkg output is
+.I not
+shown by default.
 .
-.TP
-\fB\-C\fR, \-\-downgrade [package(s)]
+After building, the built
+.I *.pkg.tar.xz
+file is moved to the package cache and installed from there.
 .
-Perform actions involving the package [C]ache. Default action downgrades
-specified packages. This process is interactive, allowing the user to choose
-from any previous version they have available in the package cache.
+This allows for easy AUR package downgrading.
 .
 .TP
-\fB\-L\fR, \-\-viewlog
+.BR -B ", " \-\-save
 .
-Perform actions involving the pacman [L]ogfile.
+Manage the saving and restoring of the global package state.
+.
+Default action stores a record of all currently installed packages and their
+versions.
+.
+.TP
+.BR -C ", " \-\-downgrade " \*[packages-optional]"
+.
+Perform actions involving the package
+.BR C ache.
+.
+Default action downgrades specified
+.IR packages .
+.
+.IP
+This process is interactive, allowing the user to choose from any previous
+version they have available in the package cache.
+.
+.TP
+.BR \-L ", " \-\-viewlog
+.
+Perform actions involving the pacman
+.BR L ogfile.
+.
 Default action opens the log for read-only viewing.
 .
 .TP
-\fB\-O\fR, \-\-orphans [package(s)]
+.BR \-O ", " \-\-orphans " \*[packages-optional]"
 .
-Perform actions involving [O]rphan packages. Orphan packages are packages
-installed as dependencies, but are no longer required by any other package.
+Perform actions involving
+.BR O rphan
+packages.
+.
 Default action is to list the current orphans.
 .
-.TP
-\fB\-P\fR, \-\-analysis <stdin>
+.IP
+Orphan packages are packages installed as dependencies,
+but are no longer required by any other package.
 .
-Perform security analysis of a [P]KGBUILD. Useful for package maintainers and
-sysadmins to verify the safety of the PKGBUILD files that they write. To test
-any package on the AUR, try the following:
+.TP
+.BR \-P ", " \-\-analysis
+.
+Perform security analysis of a
+.BR P KGBUILD.
+.
+Default action reads PKGBUILD from stdin.
+.
+.IP
+Useful for package maintainers and sysadmins to verify the safety of the
+PKGBUILD files that they write.
+.
+To test any package on the AUR, try the following:
 .
 .RSAMPLE
-aura -Ap <package> | aura -P
+.BI "aura -Ap " "package" " | aura -P"
 .ERSAMPLE
 .
-.SH AUR SYNC OPTIONS (\fI\-A\fP)
+.SH AUR SYNC OPTIONS (\fR\-A\fP)
 .
 .TP
-\fB\-a\fR, \-\-delmakedeps
+.BR \-a ", " \-\-delmakedeps
 .
 Uninstalls build dependencies that are no longer required after installing the
-main package. This prevents the creation of orphan packages. Also note that
-while the package itself will be uninstalled, its package file will remain in
-the cache.
+main package.
+.
+This prevents the creation of orphan packages.
+.
+Also note that while the package itself will be uninstalled,
+its package file will remain in the cache.
 .
 .TP
-\fB\-c\fR, \-\-clean
+.BR \-c ", " \-\-clean
 .
 After a package's tarball has been built and copied to the package cache,
 delete its build directory immediately.
 .
 .TP
-\fB\-d\fR, \-\-deps <package(s)>
+.BR \-d ", " \-\-deps " \*[packages]"
 .
-View all the dependencies of a package. This process is recursive for AUR
-packages, so all dependencies of dependencies (and so on) will also be shown.
+View all dependencies of
+.IR packages .
+.
+This process is recursive for AUR packages,
+so all dependencies of dependencies (and so on) will also be shown.
+.
 This can aid the pre-install package research process.
 .
 .TP
-\fB\-i\fR, \-\-info <package(s)>
+.BR \-i ", " \-\-info " \*[packages]"
 .
-View information about a package in the AUR.
-.
-.TP
-\fB\-k\fR, \-\-diff
-.
-Shows PKGBUILD diffs. When upgrading, using this option will compare the most
-and second-most recent PKGBUILDs and output changes in colour.
+View information about AUR
+.IR packages .
 .
 .TP
-\fB\-p\fR, \-\-pkgbuild <package(s)>
+.BR \-k ", " \-\-diff
 .
-Outputs an AUR package's PKGBUILD. Use this before installing new packages to
-confirm that the build scripts aren't doing anything fishy.
+Show PKGBUILD diffs.
 .
-.TP
-\fB\-q\fR, \-\-quiet
-.
-Display less information about certain aursync operations (this is useful when
-processing Aura's output in a script). In particular, search and view
-dependencies will only show uncoloured package names.
+When upgrading, using this option will compare the most and second-most recent
+PKGBUILDs and output changes in colour.
 .
 .TP
-\fB\-s\fR, \-\-search <word>
+.BR \-p ", " \-\-pkgbuild " \*[packages]"
 .
-Search the AUR via a word only (no regex). Results are sorted by vote.
+View PKGBUILDs of AUR
+.IR packages .
+.
+Use this before installing new packages to confirm that the build scripts
+aren't doing anything fishy.
+.
+.TP
+.BR \-q ", " \-\-quiet
+.
+Display less information about certain
+.B \-A
+operations
+(this is useful when processing Aura's output in a script).
+.
+In particular, search and view dependencies will only show uncoloured package
+names.
+.
+.TP
+.BR \-s ", " \-\-search " \*[multi word]"
+.
+Search AUR for packages containing
+.IR word s
+(not regex) in their names or descriptions.
+.
+Multiple terms will narrow down the search.
+.
+Results are sorted by votes.
+.
 Suboptions:
 .
 .RS
 .
-.TP
-\fB\-\-abc\fR
+.  TP
+.  B \-\-abc
+.
 Sorts results alphabetically.
 .
-.TP
-\fB\-\-head\=n\fR
-Only show the first n results. Default n = 10.
+.  TP
+.  BR \-\-head [ =\fIN\fR ]
 .
-.TP
-\fB\-\-tail\=n\fR
-Only show the last n results.  Default n = 10.
+Only show the first
+.I N
+results.
+.I N
+defaults to 10.
 .
-.TP
-\fB\-r\fR, \fB\-\-both\fR
+.  TP
+.  BR \-\-tail [ =\fIN\fR ]
+.
+Only show the last
+.I N
+results.
+.I N
+defaults to 10.
+.
+.  TP
+.  BR \-r ", " \-\-both
+.
 Show results from the official repos as well.
 .
 .RE
 .
 .TP
-\fB\-u\fR, \-\-sysupgrade
+.BR \-u ", " \-\-sysupgrade
 .
-Upgrade all installed AUR packages. \fI\-Au\fR is \fI\-Su\fR for AUR packages.
-.
-.TP
-\fB\-w\fR, \-\-downloadonly <package(s)>
-.
-Download a package tarball.
-.
-.TP
-\fB\-x\fR, \-\-unsuppress
-.
-Unsuppress \fImakepkg\fR output during building. By default this output is
-suppressed for a more silent install. Note that when this option isn't used,
-\fImakepkg\fR output is actually collected and printed if any errors occur.
+Upgrade all installed AUR packages.
+.B -Au
+is like
+.B -Su
+but for AUR packages.
 .
 .TP
-\fB\-\-json\fP <package(s)>
+.BR \-w ", " \-\-downloadonly " \*[packages]"
 .
-Query the AUR RPC for package info as raw JSON. Good for debugging.
+Retrieve AUR
+.I packages
+source tarballs,
+but do not build/install/upgrade anything.
 .
 .TP
-\fB\-\-build\fR <path>
+.BR \-x ", " \-\-unsuppress
 .
-Specify build path when building AUR packages. Only the \fIfull\fR path of a
-pre-existing directory can be used. Example:
+Unsuppress
+.BR makepkg (8)
+output during building.
+.
+By default this output is suppressed for a more silent install.
+.
+Note that when this option isn't used,
+.B makepkg
+output is actually collected and printed if any errors occur.
+.
+.TP
+.B \-\-json \*[packages]
+.
+Query the AUR RPC for
+.I packages
+info as raw JSON.
+.
+Good for debugging.
+.
+.TP
+.BI \-\-build " path"
+.
+Specify build
+.I path
+when building AUR packages.
+.
+Only the
+.I full
+path of a pre-existing directory can be used.
+.
+Example:
 .
 .RSAMPLE
 aura -A foo --build=/full/path/to/build/location/
 .ERSAMPLE
 .
 .TP
-\fB\-\-builduser\fR <username>
+.BI \-\-builduser " user"
 .
-Specify the user to build packages as. This can be useful when logged in as
-root and a build user is available.
+Specify the
+.I user
+to build packages as.
 .
-.TP
-\fB\-\-devel\fR
-.
-When ran with \fI\-Au\fR, adds all development packages to the queue of
-packages to upgrade. Devel packages are those pulled directly from online
-repositories, via git / mercurial / etc.
+This can be useful when logged in as root and a build user is available.
 .
 .TP
-\fB\-\-dryrun\fR
+.B \-\-devel
 .
-When ran with \fI\-A\fR or \fI\-Au\fR, update checks, PKGBUILD diffs, and
-dependency checks will be performed, but nothing will be built. Also usable
-with \fI\-M\fR.
+When ran with
+.BR \-Au ,
+adds all development packages to the queue of packages to upgrade.
 .
-.TP
-\fB\-\-force\fR
-.
-Always (re)build the specified packages. Usually Aura will not rebuild packages
-whose versions are already available in the local package cache.
+Devel packages are those pulled directly from online repositories,
+via git / mercurial / etc.
 .
 .TP
-\fB\-\-hotedit\fR
+.B \-\-dryrun
 .
-Prompt the user before building to ask if they wish to view/edit the PKGBUILD,
-as well as any .install or .patch files. However, research into packages (and by
-extension, their PKGBUILDs) should be done by the user before any building
-occurs. Please use \fI\-Ap\fR and \fI\-Ad\fR for this, as they will be much
-faster at presenting information than searching the AUR website manually. Note
-that, since aura is run through sudo, your local value of $EDITOR may not be
-preserved. Run as "sudo \fI\-E\fR aura -A --hotedit ..." to preserve your
-environment. To always allow environment variables to be passed, have a look at
-the \fIenv_reset\fR and \fIenv_keep\fR options in \fBsudoers\fR(5).
+When ran with
+.BR \-A " or " \-Au ,
+update checks,
+PKGBUILD diffs,
+and dependency checks will be performed,
+but nothing will be built.
+.
+Also usable with
+.BR \-M .
 .
 .TP
-\fB\-\-skipdepcheck\fR
+.B \-\-force
 .
-Perform no dependency solving. Consider this when using \fI\-\-hotedit\fR to
-avoid building annoying dependencies that aren't necessary for your special
+Always (re)build the specified packages.
+.
+Usually Aura will not rebuild packages whose versions are already available in
+the local package cache.
+.
+.TP
+.B \-\-hotedit
+.
+Before building, prompt the user if they wish to view/edit the
+.IR PKGBUILD ,
+as well as any
+.IR .install " or " .patch
+files.
+.
+However, research into packages (and by extension, their PKGBUILDs) should be
+done by the user before any building occurs.
+.
+Please use
+.BR \-Ap " and " \-Ad
+for this,
+as they will be much faster at presenting information than searching the AUR
+website manually.
+.
+Note that, since aura is run through sudo,
+your local value of
+.RB $ EDITOR
+may not be preserved.
+.
+Run as
+\(lqsudo
+.B \-E
+aura -A --hotedit \*[ellipsis]\(rq
+to preserve your environment.
+.
+To always allow environment variables to be passed,
+have a look at the
+.IR env_reset " and " env_keep
+options in
+.BR sudoers (5).
+.
+.TP
+.B \-\-skipdepcheck
+.
+Perform no dependency solving.
+.
+Consider this when using
+.B \-\-hotedit
+to avoid building annoying dependencies that aren't necessary for your special
 use-case.
 .
 .TP
-\fB\-\-vcspath\fP \fI<path>\fP
+.BI \-\-vcspath " path"
 .
-Save the cloned sources of VCS packages (i.e. those that end in \fI*-git\fR, etc.)
-in the given location, instead of the default \fI/var/cache/aura/vcs/\fR.
+Save the cloned sources of VCS packages (i.e.\& those that end in
+.IR *-git ,
+etc.) in the given
+.IR path ,
+instead of the default
+.IR /var/cache/aura/vcs/ .
 .
-.SH GLOBAL PACKAGE STATE OPTIONS (\fI\-B\fP)
+.SH GLOBAL PACKAGE STATE OPTIONS (\fR\-B\fP)
 .
 .TP
-\fB\-c\fR, \-\-clean <states-to-retain>
+.BR \-c ", " \-\-clean \c
+.I " states-to-retain
 .
-Saves a given number of the most recently saved package states and removes the
+Retains a given number of the most recently saved package states and removes the
 rest.
 .
 .TP
-\fB\-r\fR, \-\-restore\fR
+.BR \-r ", " \-\-restore
 .
-Restores a record kept with \fI\-B\fR. Attempts to downgrade any packages that
-were upgraded since the chosen save. Will remove any that weren't installed at
-the time.
+Restores a record kept with
+.BR \-B .
+.
+Attempts to downgrade any packages that were upgraded since the chosen save.
+.
+Will remove any that weren't installed at the time.
 .
 .TP
-\fB\-l\fR, \-\-list\fR
+.BR \-l ", " \-\-list
 .
 Show all saved package state filenames.
 .
-.SH DOWNGRADE OPTIONS (\fI\-C\fP)
+.SH DOWNGRADE OPTIONS (\fR\-C\fP)
 .
 .TP
-\fB\-b\fR, \-\-backup <path>
+.BR \-b ", " \-\-backup \c
+.I " path
 .
-Backup the package cache to a given directory. The given directory must already
-exist. During copying, progress will be shown. If the copy takes too long, you
-may want to reduce the number of older versions of each package by using
-\fI\-Cc\fR.
+Backup the package cache to a given directory.
+.
+The given directory must already exist.
+.
+During copying, progress will be shown.
+.
+If the copy takes too long,
+you may want to reduce the number of older versions of each package by using
+.BR \-Cc .
 .
 .TP
-\fB\-c\fR, \-\-clean <versions-to-retain>
+.BR \-c ", " \-\-clean \c
+.I " versions-to-retain
 .
-Saves a given number of package versions for each package and deletes the rest
-from the package cache. Count is made from the most recent version, so using:
+Retains a given number of package versions for each package,
+and deletes the rest from the package cache.
+.
+Count is made from the most recent version, so using:
 .
 .RSAMPLE
 aura -Cc 3
@@ -284,125 +454,165 @@ aura -Cc 3
 .
 .IP
 would save the three most recent versions of each package file.
-Giving the number 0 as an argument is identical to \fI\-Scc\fR.
+.
+Giving the number 0 as an argument is identical to
+.BR \-Scc .
 .
 .TP
-\fB\-\-notsaved\fP
+.B \-\-notsaved
 .
-Remove only those package files which are not saved in a package record (a la \fI\-B\fR).
-.
-.TP
-\fB\-s\fR, \-\-search <regex>
-.
-Search the package cache via a regex. Any package name that matches the regex
-will be output as\-is.
-.
-.SH LOGFILE OPTIONS (\fI\-L\fP)
+Remove only those package files which are not saved in a package record (a la
+.BR \-B ).
 .
 .TP
-\fB\-i\fR, \-\-info <package(s)>
+.BR \-s ", " \-\-search \c
+.I " regex
 .
-Displays install / upgrade history for a given package. Under the `Recent
-Actions` section, only the last five entries will be displayed. If there are
-less than five actions ever performed with the package, what is available will
-be printed.
+Search the package cache via a
+.IR regex .
 .
-.TP
-\fB\-s\fR, \-\-search <regex>
+Any package name that matches the regex will be output as-is.
 .
-Search the pacman log file via a regex. Useful for singling out any and all
-actions performed on a package.
-.
-.SH ORPHAN PACKAGE OPTIONS (\fI\-O\fP)
+.SH LOGFILE OPTIONS (\fR\-L\fP)
 .
 .TP
-\fB\-a\fR, \-\-adopt <package(s)>
+.BR \-i ", " \-\-info " \*[packages]"
 .
-Mark a package as being explicitly installed (i.e. it's not a dependency).
+Displays install/upgrade history for given
+.IR packages .
+.
+Under the \(lqRecent Actions\(rq section,
+only the last five entries will be displayed.
+.
+If there are less than five actions ever performed with the package,
+what is available will be printed.
 .
 .TP
-\fB\-j\fR, \-\-abandon
+.BR \-s ", " \-\-search \c
+.I " regex
+.
+Search the pacman log file via a
+.IR regex .
+.
+Useful for singling out any and all actions performed on a package.
+.
+.SH ORPHAN PACKAGE OPTIONS (\fR\-O\fP)
+.
+.TP
+.BR \-a ", " \-\-adopt " \*[packages]"
+.
+Mark
+.I packages
+as being explicitly installed (i.e.\& it's not a dependency).
+.
+.TP
+.BR \-j ", " \-\-abandon
 .
 Uninstall all orphan packages.
 .
-.SH ANALYSIS OPTIONS (\fI\-P\fP)
+.SH ANALYSIS OPTIONS (\fR\-P\fP)
 .
 .TP
-\fB\-f\fR, \-\-file <path>
+.BR \-f ", " \-\-file \c
+.I " path
 .
-Analyse a given PKGBUILD.
-.
-.TP
-\fB\-d\fR, \-\-dir <path>
-.
-Analyse a PKGBUILD found in the specified directory.
+Analyse a PKGBUILD at the specified
+.IR path .
 .
 .TP
-\fB\-a\fR, \-\-audit
+.BR \-d ", " \-\-dir \c
+.I " path
+.
+Analyse a
+.IR path /PKGBUILD
+found in the specified directory.
+.
+.TP
+.BR \-a ", " \-\-audit
 .
 Analyse the PKGBUILDs of all locally installed AUR packages.
 .
 .SH PACMAN / AURA DUAL FUNCTIONALITY OPTIONS
 .
 .TP
-\-\-noconfirm
+.B \-\-noconfirm
 .
-Never ask for any Aura or Pacman confirmation. Any time a prompt would
-appear, say before building or installation, it is assumed the user
-answered in whatever way would progress the program.
+Never ask for any Aura or Pacman confirmation.
+.
+Any time a prompt would appear,
+say before building or installation,
+it is assumed the user answered in whatever way would progress the program.
 .
 .TP
-\-\-needed
+.B \-\-needed
 .
 Don't rebuild/reinstall packages that are already up to date.
 .
 .TP
-\-\-debug
+.B \-\-debug
 .
 View some handy debugging information.
 .
 .TP
-\-\-color [mode]
+.BI \-\-color " when"
 .
-Whether or not to colour output text. Without this flag, both Aura and Pacman
-will attempt to colour text if the terminal allows it. Otherwise, you can pass
-\fInever\fR or \fIalways\fR to be specific about your wants.
+Specify when to enable colouring.
+.
+Without this flag, both Aura and Pacman will attempt to colour text if the
+terminal allows it.
+.
+Otherwise, you can pass
+.BR always " or " never
+to be specific about your wants.
 .
 .TP
-\-\-overwrite <glob>
+.BI \-\-overwrite " glob"
 .
-If there are file conflicts during installation, overwrite conflicting files
-that match the given glob pattern.
+If there are file conflicts during installation,
+overwrite conflicting files that match the given
+.I glob
+pattern.
 .
 .SH EXPOSED MAKEPKG OPTIONS
 .
 .TP
-\-\-ignorearch
+.B \-\-ignorearch
 .
 Ignores processor architecture when building packages.
 .
 .TP
-\-\-allsource
+.B \-\-allsource
 .
-Creates a \fI.src\fR file containing all the downloaded sources (code, etc) and
-stores it at \fI/var/cache/aura/src/\fR. To change the location where sources
-are stored, use the \fI\-\-allsourcepath\fR flag.
+Creates a
+.I .src
+file containing all the downloaded sources (code, etc.\&)
+and stores it at
+.IR /var/cache/aura/src/ .
+.
+To change the location where sources are stored,
+use the
+.B \-\-allsourcepath
+flag on command line or via
+.BR aura.conf (5).
 .
 .TP
-\-\-skipinteg
+.B \-\-skipinteg
 .
-Skip package source integrity checks.
+Skip package source integrity checks (hash sums).
 .
 .TP
-\-\-skippgpcheck
+.B \-\-skippgpcheck
 .
 Skip all PGP checks.
 .
 .SH LANGUAGE OPTIONS
 .
-Aura is available in multiple languages. As options, they can be used with
-either their English names or their real names written in their native
-characters. The available languages are, in option form:
+Aura is available in multiple languages.
+.
+As options, they can be used with either their English names or their real
+names written in their native characters.
+.
+The available languages are, in option form:
 .
 .TS \" Tab-separated
 l l.
@@ -428,27 +638,47 @@ l l.
 .SH PRO TIPS
 .
 .IP \(bu 2n
-If you build a package and then choose not to install it, the built package
-file will still be moved to the cache. You can then install it whenever you
-want with \fI\-C\fR.
+.
+If you build a package and then choose not to install it,
+the built package file will still be moved to the cache.
+You can then install it whenever you want with
+.BR \-C .
 .
 .IP \(bu 2n
-Research packages using \fI\-Ad\fR, \fI\-Ai\fR, and \fI\-Ap\fR!
+.
+Research packages using
+.BR \-Ad \ ( \-\-deps ),
+.BR \-Ai \ ( \-\-info )
+and
+.BR \-Ap \ ( \-\-pkgbuild )!
 .
 .IP \(bu 2n
-When upgrading, use \fI\-Akua\fR instead of just \fI\-Au\fR.  This will
-remove make deps, as well as show PKGBUILD diffs before building.
+.
+When upgrading, use
+.B \-Akua
+instead of just
+.BR \-Au .
+.
+This will remove make deps, as well as show PKGBUILD diffs before building.
 .
 .SH SEE ALSO
 .
-\fBaura.conf(5)\fR, \fBpacman\fR(8), \fBpacman.conf\fR(5), \fBmakepkg\fR(8)
+.BR aura.conf (5),
+.BR pacman (8),
+.BR pacman.conf (5),
+.BR makepkg (8)
 .
 .SH BUGS
 .
-It is not recommended to install non-AUR packages with pacman or aura. Aura will
-assume they are AUR packages during a \fI\-Au\fR and attempt to upgrade them. If
-a name collision occurs (that is, if there is a legitimate AUR package with the
-same name as the one you installed) previous installations could be overwritten.
+It is not recommended to install non-AUR packages with pacman or aura.
+.
+Aura will assume they are AUR packages during a
+.B \-Au
+and attempt to upgrade them.
+.
+If a name collision occurs (that is, if there is a legitimate AUR package with
+the same name as the one you installed) previous installations could be
+overwritten.
 .
 .SH AUTHOR
 .

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -1,7 +1,7 @@
 .\" Man page for `aura`
 .\" Written by Colin Woodbury <colin@fosskers.ca>
 .
-.TH aura 8 "2020 June" "Aura" "Aura Manual"
+.TH aura 8 "2021 January" "Aura" "Aura Manual"
 .
 .SH NAME
 aura \- A package manager for Arch Linux and the AUR.

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -142,7 +142,7 @@ suppressed for a more silent install. Note that when this option isn't used,
 \fImakepkg\fR output is actually collected and printed if any errors occur.
 .RE
 .P
-\fB\-\-json <package(s)>
+\fB\-\-json\fP <package(s)>
 .RS 4
 Query the AUR RPC for package info as raw JSON. Good for debugging.
 .RE
@@ -203,7 +203,7 @@ avoid building annoying dependencies that aren't necessary for your special
 use-case.
 .RE
 .P
-\fB\-\-vcspath <path>\fR
+\fB\-\-vcspath\fP \fI<path>\fP
 .RS 4
 Save the cloned sources of VCS packages (i.e. those that end in \fI*-git\fR, etc.)
 in the given location, instead of the default \fI/var/cache/aura/vcs/\fR.
@@ -229,7 +229,7 @@ Show all saved package state filenames.
 .RE
 .
 .SH DOWNGRADE OPTIONS (\fI\-C\fP)
-\fB\-b\fR, \-\-backup\fR <path>
+\fB\-b\fR, \-\-backup <path>
 .RS 4
 Backup the package cache to a given directory. The given directory must already
 exist. During copying, progress will be shown. If the copy takes too long, you
@@ -248,7 +248,7 @@ would save the three most recent versions of each package file.
 Giving the number 0 as an argument is identical to \fI\-Scc\fR.
 .RE
 .P
-\fB\-\-notsaved
+\fB\-\-notsaved\fP
 .RS 4
 Remove only those package files which are not saved in a package record (a la \fI\-B\fR).
 .RE

--- a/aura/doc/aura.8
+++ b/aura/doc/aura.8
@@ -64,7 +64,7 @@ any package on the AUR, try the following:
 aura -Ap <package> | aura -P
 .RE
 .
-.SH AUR SYNC OPTIONS (\fI\-A\fR)
+.SH AUR SYNC OPTIONS (\fI\-A\fP)
 \fB\-a\fR, \-\-delmakedeps
 .RS 4
 Uninstalls build dependencies that are no longer required after installing the
@@ -209,7 +209,7 @@ Save the cloned sources of VCS packages (i.e. those that end in \fI*-git\fR, etc
 in the given location, instead of the default \fI/var/cache/aura/vcs/\fR.
 .RE
 .
-.SH GLOBAL PACKAGE STATE OPTIONS (\fI\-B\fR)
+.SH GLOBAL PACKAGE STATE OPTIONS (\fI\-B\fP)
 \fB\-c\fR, \-\-clean <states-to-retain>
 .RS 4
 Saves a given number of the most recently saved package states and removes the
@@ -228,7 +228,7 @@ the time.
 Show all saved package state filenames.
 .RE
 .
-.SH DOWNGRADE OPTIONS (\fI\-C\fR)
+.SH DOWNGRADE OPTIONS (\fI\-C\fP)
 \fB\-b\fR, \-\-backup\fR <path>
 .RS 4
 Backup the package cache to a given directory. The given directory must already
@@ -259,7 +259,7 @@ Search the package cache via a regex. Any package name that matches the regex
 will be output as\-is.
 .RE
 .
-.SH LOGFILE OPTIONS (\fI\-L\fR)
+.SH LOGFILE OPTIONS (\fI\-L\fP)
 \fB\-i\fR, \-\-info <package(s)>
 .RS 4
 Displays install / upgrade history for a given package. Under the `Recent
@@ -274,7 +274,7 @@ Search the pacman log file via a regex. Useful for singling out any and all
 actions performed on a package.
 .RE
 .
-.SH ORPHAN PACKAGE OPTIONS (\fI\-O\fR)
+.SH ORPHAN PACKAGE OPTIONS (\fI\-O\fP)
 \fB\-a\fR, \-\-adopt <package(s)>
 .RS 4
 Mark a package as being explicitly installed (i.e. it's not a dependency).
@@ -285,7 +285,7 @@ Mark a package as being explicitly installed (i.e. it's not a dependency).
 Uninstall all orphan packages.
 .RE
 .
-.SH ANALYSIS OPTIONS (\fI\-P\fR)
+.SH ANALYSIS OPTIONS (\fI\-P\fP)
 \fB\-f\fR, \-\-file <path>
 .RS 4
 Analyse a given PKGBUILD.

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -25,7 +25,6 @@ aura.conf \- Configuration for the Aura Package Manager
 /etc/aura.conf
 .
 .SH DESCRIPTION
-.P
 Aura can be configured at runtime by commandline flags, but for users who use
 the same options all the time (say, build paths or language flags) this can be
 verbose. \fIaura.conf\fR lets you make these common settings permanent.
@@ -45,7 +44,6 @@ editor = vi
 .ESAMPLE
 .
 .SH OPTIONS
-.P
 .B language
 .RS 4
 Aura can be used in different human languages. This field must be a 2-letter
@@ -120,9 +118,7 @@ The editor to use during \fI\-\-hotedit\fR.
 .RE
 .
 .SH SEE ALSO
-.P
 aura(8)
 .
 .SH AUTHOR
-.P
 Colin Woodbury <colin@fosskers.ca>

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -1,11 +1,11 @@
 .\" Man page for `aura.conf`
 .\" Written by Colin Woodbury <colin@fosskers.ca>
-
+.
 .TH aura.conf 5 "2020 May" "Aura" "Aura Manual"
-
+.
 .\" Disable hyphenation.
 .nh
-
+.
 .de SAMPLE
 .br
 .RS
@@ -17,19 +17,19 @@
 .fi
 .RE
 ..
-
+.
 .SH NAME
 aura.conf \- Configuration for the Aura Package Manager
-
+.
 .SH SYNOPSIS
 /etc/aura.conf
-
+.
 .SH DESCRIPTION
 .P
 Aura can be configured at runtime by commandline flags, but for users who use
 the same options all the time (say, build paths or language flags) this can be
 verbose. \fIaura.conf\fR lets you make these common settings permanent.
-
+.
 .SH EXAMPLE
 .SAMPLE
 # --- Language --- #
@@ -43,14 +43,14 @@ vcspath = /var/cache/aura/vcs
 # --- Misc. --- #
 editor = vi
 .ESAMPLE
-
+.
 .SH OPTIONS
 .P
 .B language
 .RS 4
 Aura can be used in different human languages. This field must be a 2-letter
 language code, similar to those used in LOCALE. The available codes are:
-
+.
 .SAMPLE
 |------+------------|
 | Code | Language   |
@@ -79,50 +79,50 @@ language code, similar to those used in LOCALE. The available codes are:
 |------+------------|
 .ESAMPLE
 .RE
-
+.
 .P
 .B user
 .RS 4
 The real, non-sudo user to build packages as.
 .RE
-
+.
 .P
 .B buildpath
 .RS 4
 The location on the filesystem in which to build packages.
 .RE
-
+.
 .P
 .B allsourcepath
 .RS 4
 The location on the filesystem in which to save "source packages" built with
 \fI\-\-allsource\fR.
 .RE
-
+.
 .P
 .B vcspath
 .RS 4
 The location on the filesystem in which to store the cloned repositories of
 \fI*-git\fR, etc., packages.
 .RE
-
+.
 .P
 .B analyse
 .RS 4
 Aura automatically scans PKGBUILDs for malicious bash usage and other "bad
 practices". Set this to \fIFalse\fR to turn this off.
 .RE
-
+.
 .P
 .B editor
 .RS 4
 The editor to use during \fI\-\-hotedit\fR.
 .RE
-
+.
 .SH SEE ALSO
 .P
 aura(8)
-
+.
 .SH AUTHOR
 .P
 Colin Woodbury <colin@fosskers.ca>

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -1,7 +1,7 @@
 .\" Man page for `aura.conf`
 .\" Written by Colin Woodbury <colin@fosskers.ca>
 .
-.TH aura.conf 5 "2020 May" "Aura" "Aura Manual"
+.TH aura.conf 5 "2021 January" "Aura" "Aura Manual"
 .
 .de SAMPLE
 .br

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -3,16 +3,22 @@
 .
 .TH aura.conf 5 "2021 January" "Aura" "Aura Manual"
 .
-.de SAMPLE
-.br
-.RS
-.nf
-.nh
+.de SAMPLE      \" Indented example - on its own paragraph.
+.  P
+.  RS
+.  EX
 ..
-.de ESAMPLE
-.hy
-.fi
-.RE
+.de ESAMPLE     \" End of Indented example.
+.  EE
+.  RE
+..
+.de RSAMPLE     \" Relative sample - even more indented example.
+.  RS
+.  SAMPLE
+..
+.de ERSAMPLE    \" End of Relative sample.
+.  ESAMPLE
+.  RE
 ..
 .
 .SH NAME

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -16,7 +16,7 @@
 ..
 .
 .SH NAME
-aura.conf \- Configuration for the Aura Package Manager
+aura.conf \- aura package manager configuration file
 .
 .SH SYNOPSIS
 /etc/aura.conf

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -3,9 +3,6 @@
 .
 .TH aura.conf 5 "2020 May" "Aura" "Aura Manual"
 .
-.\" Disable hyphenation.
-.nh
-.
 .de SAMPLE
 .br
 .RS

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -1,3 +1,4 @@
+'\" t
 .\" Man page for `aura.conf`
 .\" Written by Colin Woodbury <colin@fosskers.ca>
 .
@@ -22,106 +23,113 @@
 ..
 .
 .SH NAME
+.
 aura.conf \- aura package manager configuration file
 .
 .SH SYNOPSIS
+.
 /etc/aura.conf
 .
 .SH DESCRIPTION
+.
 Aura can be configured at runtime by commandline flags, but for users who use
 the same options all the time (say, build paths or language flags) this can be
 verbose. \fIaura.conf\fR lets you make these common settings permanent.
 .
 .SH EXAMPLE
+.
+Overview of options in \fIaura.conf\fR:
+.
 .SAMPLE
-# --- Language --- #
-language = en  # English.
+#
+# aura.conf
+#
 
-# --- Build Settings --- #
+#[ Language ]
+language = en
+
+#[ Build Settings ]
 user = <you>
 buildpath = /tmp
 vcspath = /var/cache/aura/vcs
 
-# --- Misc. --- #
+#[ Misc. ]
 editor = vi
 .ESAMPLE
 .
 .SH OPTIONS
+.
+.TP
 .B language
-.RS 4
+.
 Aura can be used in different human languages. This field must be a 2-letter
 language code, similar to those used in LOCALE. The available codes are:
 .
-.SAMPLE
-|------+------------|
-| Code | Language   |
-|------+------------|
-| nl   | Dutch      |
-| en   | English    |
-| de   | German     |
-| nb   | Norwegian  |
-| sv   | Swedish    |
-|------+------------|
-| fr   | French     |
-| it   | Italian    |
-| pt   | Portuguese |
-| es   | Spanish    |
-|------+------------|
-| hr   | Croatian   |
-| pl   | Polish     |
-| ru   | Russian    |
-| sr   | Serbian    |
-|------+------------|
-| zh   | Chinese    |
-| id   | Indonesian |
-| ja   | Japanese   |
-|------+------------|
-| eo   | Esperanto  |
-|------+------------|
-.ESAMPLE
-.RE
+.TS \" Tab-separated
+box;
+l l.
+Code	Language
+
+nl	Dutch
+en	English
+de	German
+nb	Norwegian
+sv	Swedish
+
+fr	French
+it	Italian
+pt	Portuguese
+es	Spanish
+
+hr	Croatian
+pl	Polish
+ru	Russian
+sr	Serbian
+
+zh	Chinese
+id	Indonesian
+ja	Japanese
+
+eo	Esperanto
+.TE
 .
-.P
+.TP
 .B user
-.RS 4
+.
 The real, non-sudo user to build packages as.
-.RE
 .
-.P
+.TP
 .B buildpath
-.RS 4
-The location on the filesystem in which to build packages.
-.RE
 .
-.P
+The location on the filesystem in which to build packages.
+.
+.TP
 .B allsourcepath
-.RS 4
+.
 The location on the filesystem in which to save "source packages" built with
 \fI\-\-allsource\fR.
-.RE
 .
-.P
+.TP
 .B vcspath
-.RS 4
+.
 The location on the filesystem in which to store the cloned repositories of
 \fI*-git\fR, etc., packages.
-.RE
 .
-.P
+.TP
 .B analyse
-.RS 4
+.
 Aura automatically scans PKGBUILDs for malicious bash usage and other "bad
 practices". Set this to \fIFalse\fR to turn this off.
-.RE
 .
-.P
+.TP
 .B editor
-.RS 4
+.
 The editor to use during \fI\-\-hotedit\fR.
-.RE
 .
 .SH SEE ALSO
+.
 aura(8)
 .
 .SH AUTHOR
+.
 Colin Woodbury <colin@fosskers.ca>

--- a/aura/doc/aura.conf.5
+++ b/aura/doc/aura.conf.5
@@ -32,13 +32,16 @@ aura.conf \- aura package manager configuration file
 .
 .SH DESCRIPTION
 .
-Aura can be configured at runtime by commandline flags, but for users who use
-the same options all the time (say, build paths or language flags) this can be
-verbose. \fIaura.conf\fR lets you make these common settings permanent.
+Aura can be configured at runtime by commandline flags,
+but for users who use the same options all the time
+(say, build paths or language flags) this can be verbose.
+.I aura.conf
+lets you make these common settings permanent.
 .
 .SH EXAMPLE
 .
-Overview of options in \fIaura.conf\fR:
+Overview of options in
+.IR aura.conf :
 .
 .SAMPLE
 #
@@ -62,8 +65,10 @@ editor = vi
 .TP
 .B language
 .
-Aura can be used in different human languages. This field must be a 2-letter
-language code, similar to those used in LOCALE. The available codes are:
+Aura can be used in different human languages.
+This field must be a 2-letter language code,
+similar to those used in LOCALE.
+The available codes are:
 .
 .TS \" Tab-separated
 box;
@@ -107,7 +112,7 @@ The location on the filesystem in which to build packages.
 .B allsourcepath
 .
 The location on the filesystem in which to save "source packages" built with
-\fI\-\-allsource\fR.
+.BR \-\-allsource .
 .
 .TP
 .B vcspath
@@ -118,17 +123,21 @@ The location on the filesystem in which to store the cloned repositories of
 .TP
 .B analyse
 .
-Aura automatically scans PKGBUILDs for malicious bash usage and other "bad
-practices". Set this to \fIFalse\fR to turn this off.
+Aura automatically scans PKGBUILDs for malicious bash usage
+and other "bad practices".
+Set this to
+.B False
+to turn off.
 .
 .TP
 .B editor
 .
-The editor to use during \fI\-\-hotedit\fR.
+The editor to use during
+.BR \-\-hotedit .
 .
 .SH SEE ALSO
 .
-aura(8)
+.BR aura (8)
 .
 .SH AUTHOR
 .

--- a/aura/doc/completions/_aura
+++ b/aura/doc/completions/_aura
@@ -128,9 +128,9 @@ _aura_opts_sync_modifiers=(
 # options for passing to _arguments: options for --aursync command
 _aura_opts_aursync_actions=(
     '(-A --aursync)'{-A,--aursync}
-    {-p,--pkgbuild}'[Display an AUR package PKGBUILD]'
+    {-p,--pkgbuild}'[Display AUR package PKGBUILD]'
     {-s,--search}'[Search AUR package names and descriptions]'
-    {-w,--downloadonly}'[Download an AUR package source tarball]'
+    {-w,--downloadonly}'[Download AUR packages source tarball]'
 )
 
 # options for passing to _arguments: options for --aursync command


### PR DESCRIPTION
Just some minor quality-of-life improvements.

@fosskers May I have your permission to rewrite these man pages into more canonical form suggested by **groff_man**(7)? What do I mean by this is:

 - One sub-sentence per line (line breaks after dots, commas etc.),
 - Use `.TP` macro for options,
 - Use `.B`, `.I` etc. extensively instead of inline font escapes (`\fN`) -- mostly because double click source text selection sucks with `\fIinline \fBgroff\fRescapes`,
 - Wrap options (both short and long) in bold, and their arguments in italic and without brackets (ex: **-s**, **--search** _regex_).

Ideally, I'd like to rewrite everything in `-mdoc` **groff_mdoc**(7) instead of `-man`, because mdoc provides a semantic markup instead of direct font manipulation. But it looks so complex at first glance, that most of the world sticks with plain old **groff_man**(7).

---

So basically, I'm a lazy `-Ass` loafer, who could have done this PR literally two month ago, but instead invested time into studying groff, contributing to GNU and doing loadshit of irrelevant stuff, up to the point of designing full-brown syntax highlighter & plugin for Sublime Text, when in fact all I originally wanted to do is to fix those damn closing brackets sections headers ( ec870fc ).

Shame on me, it should have been hacktoberfest contribution, but whatever. I've completed the challenge by other means anyways.