### PR TITLE
Add git feature

### DIFF
--- a/rust/aura/Cargo.toml
+++ b/rust/aura/Cargo.toml
@@ -23,3 +23,7 @@ simplelog = "0.8"
 ubyte = "0.10"
 unic-langid = { version = "0.9", features = ["macros"] }
 webbrowser = "0.5"
+
+[features]
+git = ["alpm/git"]
+


### PR DESCRIPTION
This allows building aura against pacman-git.

This feature can automatically be endabled by the pkgbuild when there is
one.