### PR TITLE
Designer name credits update

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Aura has been translated by these generous people:
 | Swedish    | Fredrik Haikarainen and Daniel Beecham          |
 | Turkish    | Cihan Alkan                                     |
 
-Aura's logo is thanks to the designer [Atra](https://github.com/estatra).
+Aura's logo is thanks to the designer [Cristiano Vitorino](https://github.com/cristianovitorino).
 
 # The `aur` Haskell Library
 

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -24,6 +24,6 @@ Tracker!](https://github.com/fosskers/aura/issues)
 Channel!](https://gitter.im/aurapm/aura)
 - **Who translated Aura?** [These fine
   people](https://github.com/fosskers/aura#credits) from all over the world!
-- **Who made that neat logo?** The designer [Atra](https://github.com/estatra)!
+- **Who made that neat logo?** The designer [Cristiano Vitorino](https://github.com/cristianovitorino)!
 - **Who is the original author of Aura?** [Colin
   Woodbury](https://www.fosskers.ca) from Canada!


### PR DESCRIPTION
Hey Colin, Cristiano A.K.A. Atra here, I designed the project logo. Employers prefer to see my real name on Open Source projects I collaborate, so I'll have to use that from now on. Sorry for the inconvenience.