### PR TITLE
Add raur-curl

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["aura", "aura-core", "aura-arch", "aura-common"]
+members = ["aura", "aura-core", "aura-arch", "aura-common", "raur-curl"]
 
 [patch.crates-io]
 # i18n-embed-fl = { git = "https://github.com/fosskers/cargo-i18n", rev = "1f26b5458c75a732fd5b0bd27f88672b2a04b046" }

--- a/rust/raur-curl/Cargo.toml
+++ b/rust/raur-curl/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "raur-curl"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+curl = "0.4.36"
+raur = { version = "5.0.1", default-features = false, features = ["blocking-trait"], git = "https://gitlab.com/davidbittner/raur/"}
+serde = "1.0.125"
+serde_derive = "1.0.125"
+serde_json = "1.0.64"
+
+

--- a/rust/raur-curl/src/lib.rs
+++ b/rust/raur-curl/src/lib.rs
@@ -1,0 +1,164 @@
+use curl::easy::Easy;
+use raur::blocking::Raur;
+use raur::{Package, SearchBy};
+use serde_derive::Deserialize;
+use std::cell::RefCell;
+use std::fmt;
+
+#[derive(Deserialize)]
+struct Response {
+    #[serde(rename = "type")]
+    response_type: String,
+    error: Option<String>,
+    results: Vec<Package>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Curl(curl::Error),
+    Aur(String),
+    Serde(serde_json::Error),
+}
+
+impl From<curl::Error> for Error {
+    fn from(e: curl::Error) -> Self {
+        Error::Curl(e)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Error::Serde(e)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Curl(e) => e.fmt(f),
+            Error::Aur(e) => e.fmt(f),
+            Error::Serde(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+#[derive(Debug)]
+pub struct Handle {
+    curl: RefCell<Easy>,
+    url: String,
+}
+
+impl Default for Handle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Handle {
+    pub fn new() -> Handle {
+        Handle {
+            curl: RefCell::new(Easy::new()),
+            url: raur::AUR_URL.to_string(),
+        }
+    }
+
+    pub fn new_with_settings<S: Into<String>>(curl: Easy, url: S) -> Handle {
+        Handle {
+            curl: RefCell::new(curl),
+            url: url.into(),
+        }
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    fn perform(curl: &mut Easy) -> Result<Vec<Package>, Error> {
+        let mut json = Vec::<u8>::new();
+        let mut transfer = curl.transfer();
+        transfer.write_function(|data| {
+            json.extend(data);
+            Ok(data.len())
+        })?;
+
+        transfer.perform()?;
+        drop(transfer);
+
+        let response: Response = serde_json::from_slice(&json)?;
+
+        if response.response_type == "error" {
+            Err(Error::Aur(
+                response
+                    .error
+                    .unwrap_or_else(|| "No error message provided".to_string()),
+            ))
+        } else {
+            Ok(response.results)
+        }
+    }
+}
+
+impl Raur for Handle {
+    type Err = Error;
+
+    fn raw_info<S: AsRef<str>>(&self, pkg_names: &[S]) -> Result<Vec<Package>, Error> {
+        let mut curl = self.curl.borrow_mut();
+        let mut url = self.url.clone();
+        url.push_str("?v=5&type=info");
+        for pkg in pkg_names {
+            url.push_str("&arg[]=");
+            url.push_str(&curl.url_encode(pkg.as_ref().as_bytes()));
+        }
+        curl.url(&url)?;
+        Self::perform(&mut *curl)
+    }
+
+    fn search_by<S: AsRef<str>>(
+        &self,
+        query: S,
+        strategy: SearchBy,
+    ) -> Result<Vec<Package>, Error> {
+        let mut curl = self.curl.borrow_mut();
+        let url = format!(
+            "{}?v=5&type=search&by={}&arg={}",
+            self.url,
+            strategy,
+            curl.url_encode(query.as_ref().as_bytes())
+        );
+        curl.url(&url)?;
+        Self::perform(&mut *curl)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search() {
+        let handle = Handle::default();
+
+        let query = handle.search("zzzzzzz").unwrap();
+        assert_eq!(0, query.len());
+
+        let query = handle.search("spotify").unwrap();
+        assert!(!query.is_empty());
+        assert!(query[0].url.is_some());
+    }
+
+    #[test]
+    fn test_info() {
+        let handle = Handle::default();
+
+        let query = handle.info(&["pacman-git"]).unwrap();
+        assert_eq!(query[0].name, "pacman-git");
+
+        let query = handle.info(&["screens", "screens-git"]);
+        assert!(query.is_ok());
+
+        let query = query.unwrap();
+        assert_eq!(2, query.len());
+    }
+}


### PR DESCRIPTION
raur-curl is an implementation of the raur API using curl as a back end.
It's pretty self contained so I've put it in its own crate.

This depends on the git version of raur. Once it's had some use here and
deemed suitable I'll push a new vesion of raur.