### PR TITLE
Update book links

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -16,12 +16,12 @@ jobs:
       - name: Install mdbook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: "0.3.7"
+          mdbook-version: "0.4.7"
 
       - name: Generate book from markdown
         run: |
-            cd book
-            mdbook build
+          cd book
+          mdbook build
 
       - name: Publish HTML
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup GHC
         uses: actions/setup-haskell@v1.1.4
         with:
-          ghc-version: "8.10.3"
+          ghc-version: "8.10.4"
           enable-stack: true
 
       - name: Clone project

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -7,7 +7,7 @@
 Welcome to the User Guide for Aura, a secure, multilingual package manager for
 Arch Linux.
 
-Aura's original purpose is as an *AUR helper*, in that it automates the process
+Aura's original purpose is as an _AUR helper_, in that it automates the process
 of installing packages from the Arch User Repositories. It is, however, capable
 of much more.
 
@@ -18,12 +18,14 @@ into [Installation](install.md)!
 
 ## Contact
 
-- **Found an issue with Aura?** [Visit our Bug
-Tracker!](https://github.com/fosskers/aura/issues)
-- **Want to speak to an Aura dev directly?** [Visit our Gitter
-Channel!](https://gitter.im/aurapm/aura)
-- **Who translated Aura?** [These fine
-  people](https://github.com/fosskers/aura#credits) from all over the world!
-- **Who made that neat logo?** The designer [Cristiano Vitorino](https://github.com/cristianovitorino)!
-- **Who is the original author of Aura?** [Colin
-  Woodbury](https://www.fosskers.ca) from Canada!
+- **Found an issue with Aura?** [Visit our Bug Tracker!][tracker]
+- **Want to speak to an Aura dev directly?** [Visit our Discussions forum!][discussions]
+- **Who translated Aura?** [These fine people][credits] from all over the world!
+- **Who made that neat logo?** The designer [Cristiano Vitorino][logo]!
+- **Who is the original author of Aura?** [Colin Woodbury][colin] from Canada!
+
+[tracker]: https://github.com/fosskers/aura/issues
+[discussions]: https://github.com/fosskers/aura/discussions
+[credits]: https://github.com/fosskers/aura#credits
+[logo]: https://github.com/cristianovitorino
+[colin]: https://www.fosskers.ca

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.5
+resolver: lts-17.11
 
 ghc-options:
   $everything: -split-sections -haddock
@@ -6,6 +6,12 @@ ghc-options:
 
 nix:
   shell-file: nix/stack.nix
+
+flags:
+  these:
+    assoc: false
+  strict:
+    assoc: false
 
 packages:
   - aura/

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 565266
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/5.yaml
-    sha256: 78e8ebabf11406261abbc95b44f240acf71802630b368888f6d758de7fc3a2f7
-  original: lts-17.5
+    size: 567672
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/11.yaml
+    sha256: 03181cdbeb671eb605bbcf6f285bea4d094b6ac7433a0e14a9f1dd54ad995938
+  original: lts-17.11


### PR DESCRIPTION
We use Discussions instead of Gitter now.