### PR TITLE
Don't do multiple AUR requests for search

### DIFF
--- a/rust/aura/src/main.rs
+++ b/rust/aura/src/main.rs
@@ -17,7 +17,7 @@ use command::*;
 use error::Error;
 use flags::{SubCmd, AURA_GLOBALS};
 use simplelog::{ColorChoice, Config, TermLogger, TerminalMode};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Not;
 use std::path::{Path, PathBuf};
 
@@ -68,9 +68,7 @@ fn main() -> Result<(), Error> {
         // --- AUR Packages --- //
         SubCmd::Aur(a) if a.info.is_empty().not() => aur::info(&fll, &a.info)?,
         SubCmd::Aur(a) if a.search.is_empty().not() => {
-            // FIXME It would be great if `clap` could pull arg lists directly into a `HashSet`.
-            let terms: HashSet<_> = a.search.into_iter().collect();
-            aur::search(&alpm, a.abc, a.reverse, a.limit, a.quiet, &terms)?
+            aur::search(&alpm, a.abc, a.reverse, a.limit, a.quiet, &a.search)?
         }
         SubCmd::Aur(a) if a.open.is_some() => aur::open(&a.open.unwrap())?,
         SubCmd::Aur(_) => unimplemented!(),


### PR DESCRIPTION
Instead of doing multiple requests and filtering the results into one
list, you can achieve the same by just searching using the first term
and filtering the results by the other terms.

This ends up being faster and puts less strain on the AUR.