### PR TITLE
Bumping `versions`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup GHC
         uses: actions/setup-haskell@v1.1.4
         with:
-          ghc-version: "8.10.4"
+          ghc-version: "8.10.5"
           enable-stack: true
 
       - name: Clone project

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup GHC
         uses: actions/setup-haskell@v1.1.4
         with:
-          ghc-version: "8.10.5"
+          ghc-version: "8.10.4"
           enable-stack: true
 
       - name: Clone project

--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Aura Changelog
 
+## Unreleased
+
+#### Changed
+
+- Expect at least version `5.0` of the `versions` library.
+
+#### Fixed
+
+- Subtle bug involving tarball path parsing. [#713]
+
+[#713]: https://github.com/fosskers/aura/pull/713
+
 ## 3.2.4 (2021-03-10)
 
 #### Fixed
@@ -40,7 +52,7 @@ With this release, Aura has passed 2,000 commits. Thank you for your ongoing sup
 
 #### Changed
 
-- *Breaking:* `-As` and `-Ai` will yield an exit code of `1` if no results were
+- _Breaking:_ `-As` and `-Ai` will yield an exit code of `1` if no results were
   found. This matches `pacman`.
 - `-As` now accepts multiple search terms to narrow in on specific packages.
 
@@ -194,6 +206,7 @@ This release fixes a regression in `3.1.1`. Please update as soon as possible.
   - `-Pd` accepts a path to a directory containing a PKGBUILD.
   - `-Pa` to scan the PKGBUILDs of all locally installed AUR packages.
   - `-P` on its own will read from stdin. Combine this with `-Ap` to pull from the AUR:
+
 ```
 > aura -Ap myget | aura -P
 
@@ -202,6 +215,7 @@ This release fixes a regression in `3.1.1`. Please update as soon as possible.
 aura >>= sudo indicates that someone may be trying to gain root access to your machine.
 aura >>= Potential PKGBUILD vulnerabilities detected.
 ```
+
 - A new flag `--vcspath` to accompany the new VCS build behaviour (see below).
 - A new flag `--allsourcepath` to accompany the restored `--allsource`
   functionality (see below).
@@ -321,7 +335,7 @@ aura >>= Potential PKGBUILD vulnerabilities detected.
 ## 2.0.0
 
 This is a large update representing about a month of full-time effort. Aura is now
-*much* faster, solves dependencies more reliably, has a few new features, and
+_much_ faster, solves dependencies more reliably, has a few new features, and
 many fewer bugs. This is all while modernizing the code and seeing a ~15% decrease
 in overall code size.
 
@@ -362,7 +376,7 @@ in overall code size.
 - `-Su` and `-Au` automatically save a package state before updating (unless you're doing `--dryrun`).
   This lets you more easily roll back from problematic updates.
 - Saved package states can now be "pinned", which will protect them from removal via `-Bc`.
-  To pin a certain state, open its JSON file (see below in *Breaking Changes*) and edit the
+  To pin a certain state, open its JSON file (see below in _Breaking Changes_) and edit the
   `pinned` field from `false` to `true`.
 
 #### CLI Flags
@@ -423,33 +437,40 @@ in overall code size.
 - `makepkg` output is no longer coloured green.
 
 ## 1.4.0
-- *Dependency resolution vastly improved.* We removed the Bash parser that used
+
+- _Dependency resolution vastly improved._ We removed the Bash parser that used
   to poorly handle the bulk of this.
 - Chinese translations thanks to Kai Zhang.
 - `-M` operator and associated code fully removed.
 
 ## 1.3.9
+
 - Updated Swedish translations
 - Disabled `-M` operator due to the `abs` tool being deprecated by Arch Linux
 
 ## 1.3.8
+
 - Fixed behaviour of `-B` flags. For restoring of saved states, use the long
   form: `aura -B --restore`. Cache backups also need to take their long form: `aura -C --backup`.
 - Fixed handling of language flags. Thanks to Doug Patti!
 
 ## 1.3.5
+
 - Aura now uses version 5 of the `aur` package, to fix a critial bug
 - Updated Spanish and Polish
 
 ## 1.3.4
+
 - Bash parser bug fix. Fixes some packages.
 
 ## 1.3.3
+
 - Bash parser extended to be able to handle bash array expansions.
   This enables packages with more (Bash-wise) complex PKGBUILDs to build
   properly.
 
 ## 1.3.2.1
+
 - `-Ai` and `-As` show popularity values.
 - `aur4` is no longer referenced.
 - `Yes/No` prompts are now localized.
@@ -457,28 +478,34 @@ in overall code size.
 - Updated German translation.
 
 ## 1.3.1.0
+
 - Aura builds against GHC 7.10.
 - Updated German and Russian translations.
 
 ## 1.3.0.4
+
 - Must use `--builduser` when building as root.
 - Bug fix regarding `--needed`.
 - Updated Portuguese translation.
 
 ## 1.3.0.3
+
 - Pacman flags `--ignore` and `--ignoregroup` now work.
 - Bug fixes.
 
 ## 1.3.0.2
+
 - (Bug fix) If a user tries to install a package in `IgnorePkg`, they
   will now be prompted.
 - Man page updated.
 - Dependencies updated.
 
 ## 1.3.0.1
+
 - (Bug fix) Tarballs are now downloaded from a URL provided by the RPC.
 
 ## 1.3.0.0
+
 - Last major version of Aura 1! We have entered the design phase for Aura 2,
   the implementation of which will transform Aura into a multi-distro
   package management platform.
@@ -499,41 +526,47 @@ in overall code size.
   - Other updated translations.
 
 ## 1.2.3.4
+
 - zsh completions completely redone (thanks to Sauyon Lee!)
   Having `aur-git` installed will let you auto-complete on AUR packages.
 
 ## 1.2.3.3
+
 - `-As --{head,tail}` can now be passed numbers to truncate the results
   to any number you want. The default is 10.
 - Updated Russian translation.
 
 ## 1.2.3.2
+
 - Expanded Bash completions:
-    Aura Only
-      * Expanded completion for all options and search sub-options
-      * Package completion for -M/--abssync
-      * Completion for orphans using self-generated list
-    Pacman
-      * Include completion for all pacman options
-      * Directory or file completion for some common options
+  Aura Only
+  _ Expanded completion for all options and search sub-options
+  _ Package completion for -M/--abssync
+  _ Completion for orphans using self-generated list
+  Pacman
+  _ Include completion for all pacman options \* Directory or file completion for some common options
 - Use `--dryrun` with `-A` and `-M` install options to test everything
   up until actual building would occur (dependency checks, etc.)
 
 ## 1.2.3.1
+
 - Network.HTTP.Conduit errors are now caught properly
   and don't crash aura.
 - `customizepkg` usage corrected.
 - zsh completions slightly expanded.
 
 ## 1.2.3.0
+
 - Moved to `Network.HTTP.Conduit` from `Network.Curl`
   This fixes the AUR connection issues.
   Binary size has increased by quite a bit.
 
 ## 1.2.2.1
+
 - `-Ai` now shows dependencies.
 
 ## 1.2.2.0
+
 - Happy New Year!
 - makepkg's `--ignorearch` flag is now visible to Aura.
   This allows users to build AUR packages on ARM devices
@@ -543,6 +576,7 @@ in overall code size.
 - Bug fixes and translation updates
 
 ## 1.2.1.3
+
 - `-As` results now sort by vote. Use `--abc` to sort alphabetically.
 - "[installed]" will now be shown in `-As` results if you have it.
 - Fixed Bash parsing bug involving `\\` in arrays
@@ -551,16 +585,19 @@ in overall code size.
 - Updated French translation
 
 ## 1.2.1.2
+
 - Happy Canadian Thanksgiving
 - Bug fixes
 
 ## 1.2.1.1
+
 - Norwegian translation added!
 - Dependency checks slightly faster
 - `--hotedit` and `--custom` can now be used together
 - Bug fixes
 
 ## 1.2.1.0
+
 - New `builduser` option
 - `Prelude.head` bug fixed
 - Dependency checking is faster
@@ -569,12 +606,15 @@ in overall code size.
 - Other bug fixes
 
 ## 1.2.0.2
+
 - Bug fixes and spelling corrections.
 
 ## 1.2.0.1
+
 - Fixes dependency build order bug.
 
 ## 1.2.0.0
+
 - New operator `-M` for building ABS packages. Has its own family of options.
 - Pre-built binary package available (x86_64 only)
 - Updates to Aura are now prioritized like pacman updates.
@@ -585,50 +625,59 @@ in overall code size.
 - Extensive API changes.
 
 ## 1.1.6.2
+
 - New option `--no-pp`. Disables use of powerpill, even if you have it.
 - This is a light release, as major work is being done on version 1.2 on
   another development branch.
 
 ## 1.1.6.1
+
 - Compatable with pacman 4.1
 - All pacman-color support removed
 - `-As` output slightly altered to match pacman.
 - Bug fixes.
 
 ## 1.1.6.0
+
 - New option `--build` for specifying AUR package build path.
 - Vote number now shown in `-As` output.
 - Fixed Repo/AUR name collision bug.
 - API Change: Argument order for functions in `Aura/Languages` changed.
 
 ## 1.1.5.0
+
 - `customizepkg` now usable with Aura.
   Activate with the `--custom` option.
-- API Change: Aura/Pkgbuilds now a set of libraries as Aura/Pkgbuild/*
+- API Change: Aura/Pkgbuilds now a set of libraries as Aura/Pkgbuild/\*
 
 ## 1.1.4.3
+
 - Fixed flaw in `-Br`.
 - Fixed repititious `-Ad` output.
 - API Change: Aura/AurConnection renamed to Aura/AUR
 - API Change: function names in Aura/Languages now have better names.
 
 ## 1.1.4.2
+
 - Haskell deps have been moved back to `makedepends`.
 - haskell-http removed as dependency.
 - API Change: function naming conventions in `Aura/Languages.hs` has been
   changed. The localisation guide was also updated to reflect this.
 
 ## 1.1.4.1
+
 - Support for the $LANG environment variable.
 - Aura will now pause before post-build installation if the package database
   lock exists. This means you can run multiple instances of Aura and avoid
   crashes.
 
 ## 1.1.4.0
+
 - Serbian translation added. Thank you, Filip Brcic!
 - Fixed bug that was breaking `aura -Ss`.
 
 ## 1.1.3.0
+
 - Changed `--save` and `--restore` to `-B` and `-Br`.
   `--save` is now just an alias for `-B`, but `--restore`
   must be used with `-B`.
@@ -641,13 +690,16 @@ in overall code size.
 - Dep Change: `haskell-url` no longer needed.
 
 ## 1.1.2.1
+
 - Added message to `--save`.
 
 ## 1.1.2.0
+
 - Bash parser completely rewritten.
 - Bug fixes (thanks to the new parser)
 
 ## 1.1.1.0
+
 - New option `--devel`. Rebuilds all devel packages installed.
 - Italian translation added! Thank you Bob Valantin!
 - Support for `powerpill` added. It will be used if installed, unless
@@ -656,6 +708,7 @@ in overall code size.
 - Bug fixes
 
 ## 1.1.0.0
+
 - New `--save` and `--restore` options.
 - New option `-Ak` for showing PKGBUILD diffs when upgrading.
 - New option `--aurignore` for ignoring AUR packages.
@@ -665,18 +718,21 @@ in overall code size.
 - Code is quite cleaner now.
 
 ## 1.0.8.1
+
 - Bash completions added.
 - zsh completions added.
 - Changed `--conf` to `--viewconf`
 - Fixed bug involving "symlink" Haskell error.
 
 ## 1.0.8.0
+
 - Moved certain general functions to `Aura.Utils`
 - Moved `-L`, `-O`, `-A` functions out of `aura.hs`.
 - `--hotedit` functionality altered (fix).
 - The license message is now more badass.
 
 ## 1.0.7.0
+
 - New libraries: Aura.Time, Aura.State
 - Moved `-C` functionality to `Aura.C`
 - New secret option you don't get to find out about until 1.1
@@ -684,11 +740,13 @@ in overall code size.
 - Bug fixes
 
 ## 1.0.6.0
+
 - New libraries: ColourDiff, Data.Algorithm.Diff, Aura.Pkgbuilds
 - Aura.AuraLib split into Aura.General, Aura.Build, Aura.Dependencies
 - New secret option you don't get to find out about until 1.1
 
 ## 1.0.5.0
+
 - Fixed bug where packages with `+` in their name couldn't be
   searched or built.
 - `-As` now allows multi-word searches, as it always should have.
@@ -696,11 +754,13 @@ in overall code size.
   Still does not read the color.conf directly.
 
 ## 1.0.4.0
+
 - Added French translation. Thanks to Ma Jiehong!
 - Added Russian translation. Thanks to Kyrylo Silin!
 - Fixed bug where packages with dots in their name wouldn't build.
 
 ## 1.0.3.2
+
 - Moved haskell dependencies out of `makedepends` field and into
   `depends` field in PKGBUILD. Makedepends can usually be ignored
   after building, but haskell packages are a pain to rebuild
@@ -710,31 +770,37 @@ in overall code size.
 - Fixed pacman-color issues.
 
 ## 1.0.3.1
+
 - Added `--auradebug` option.
 
 ## 1.0.3.0
+
 - Compatibility with AUR 2.0 added.
 - Portuguese translation added. Thanks to Henry "Ingvij" Kupty!
 - Support for `pacman-color` added. Run sudo with `-E` a la:
-    sudo -E aura -Ayu
+  sudo -E aura -Ayu
 - Fixed backslash parsing bug in `Bash`.
 
 ## 1.0.2.2
+
 - Fixed parsing bug in `Bash`.
   If one package fell victim, a whole `-Au` session would fail.
 
 ## 1.0.2.1
+
 - Added License info to source files.
 - Fixed virtual package recognition bug.
 - Altered version conflict error message.
 - Fixed bug in Bash parser that would occasionally break parsing.
 
 ## 1.0.2.0
+
 - Bug fixes.
 - Extended the Bash parser. PKGBUILDs that had bash variables in their
   dependency arrays will now be parsed correctly.
 
 ## 1.0.1.0
+
 - German translation (use with --german).
   Thanks to Lukas Niederbremer!
 - Spanish translation (use with --spanish)
@@ -744,41 +810,50 @@ in overall code size.
 - Moved a number of modules to `Aura/`
 
 ## 1.0.0.0
+
 - Fixed `-V` message in terminals other than urxvt.
 - New `haskell-ansi-terminal` library to do this.
 
 ## 0.10.0.0
+
 - Internet access moved to Network.Curl library.
 - `Bash.hs` library created to help with PKGBUILD parsing.
   Can currently handle string expansions a la::
 
-    "this-is-{awesome,neat}" => ["this-is-awesome","this-is-neat"]
+  "this-is-{awesome,neat}" => ["this-is-awesome","this-is-neat"]
 
 ## 0.9.2.3
+
 - Dependency determining speed up.
 - Added AUR URL to `-Ai`.
 
 ## 0.9.3.2
+
 - Swedish translation.
   Thanks to Fredrik Haikarainen!
 
 ## 0.9.2.0
+
 - `-Ai` and `-As`!
 
 ## 0.9.1.0
+
 - `-Au` is about 20 times faster.
 
 ## 0.9.?.?
+
 - Polish translation.
   Thanks to Chris "Kwpolska" Warrick!
 - Croatian translation.
   Thanks to Denis Kasak!
 
 ## 0.9.0.0
+
 - New `-O` operation for dealing with orphan packages.
 - A man page!
 
 ## 0.8.0.0
+
 - Help message now supports multiple languages.
 - Broke "no overlapping options" convention.
 - `-Cz` is now `-Cb`.
@@ -787,17 +862,21 @@ in overall code size.
   This option shows information you can't get from looking at PKGBUILDS!
 
 ## 0.7.3.0
+
 - New option `--conf`. Lets you quickly view your pacman.conf.
 
 ## 0.7.2.3
+
 - `--log` is now `-L`.
 - New option `-Ls`. Search the log file via a regex.
 - New option `-Li`. Reports information on a given package that has had
   any appearance in the log file.
 
 ## 0.7.0.0
+
 - `--hotedit` option added.
 - `Shell` library added.
 
 ## 0.6.0.0
+
 - Aura passes proper exit codes to the shell upon completion.

--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -539,12 +539,13 @@ in overall code size.
 ## 1.2.3.2
 
 - Expanded Bash completions:
-  Aura Only
-  _ Expanded completion for all options and search sub-options
-  _ Package completion for -M/--abssync
-  _ Completion for orphans using self-generated list
-  Pacman
-  _ Include completion for all pacman options \* Directory or file completion for some common options
+  - Aura Only:
+    - Expanded completion for all options and search sub-options
+    - Package completion for -M/--abssync
+    - Completion for orphans using self-generated list
+  - Pacman
+    - Include completion for all pacman options
+    - Directory or file completion for some common options
 - Use `--dryrun` with `-A` and `-M` install options to test everything
   up until actual building would occur (dependency checks, etc.)
 

--- a/aura/aura.cabal
+++ b/aura/aura.cabal
@@ -46,7 +46,7 @@ common commons
     , megaparsec  >=7      && <10
     , rio         ^>=0.1.17
     , text        ^>=1.2
-    , versions    ^>=4.0.1
+    , versions    ^>=5
 
 common libexec
   build-depends:

--- a/aura/test/Test.hs
+++ b/aura/test/Test.hs
@@ -33,28 +33,28 @@ suite conf badRaw goodRaw = testGroup "Unit Tests"
     , testCase "parseDep - python2-lxml>=3.1.0" $ do
         let pn = "python2-lxml>=3.1.0"
             p = parseDep pn
-        p @?= Just (Dep "python2-lxml" . AtLeast . Ideal $ SemVer 3 1 0 [] [])
+        p @?= Just (Dep "python2-lxml" . AtLeast . Ideal $ SemVer 3 1 0 [] Nothing)
         fmap renderedDep p @?= Just pn
     , testCase "parseDep - foobar>1.2.3" $ do
         let pn = "foobar>1.2.3"
             p = parseDep pn
-        p @?= Just (Dep "foobar" . MoreThan . Ideal $ SemVer 1 2 3 [] [])
+        p @?= Just (Dep "foobar" . MoreThan . Ideal $ SemVer 1 2 3 [] Nothing)
         fmap renderedDep p @?= Just pn
     , testCase "parseDep - foobar=1.2.3" $ do
         let pn = "foobar=1.2.3"
             p = parseDep pn
-        p @?= Just (Dep "foobar" . MustBe . Ideal $ SemVer 1 2 3 [] [])
+        p @?= Just (Dep "foobar" . MustBe . Ideal $ SemVer 1 2 3 [] Nothing)
         fmap renderedDep p @?= Just pn
     ]
   , testGroup "Aura.Types"
     [ testCase "simplepkg"
       $ simplepkg (fromJust $ packagePath "/var/cache/pacman/pkg/linux-is-cool-3.2.14-1-x86_64.pkg.tar.xz")
-      @?= Just (SimplePkg "linux-is-cool" . Ideal $ SemVer 3 2 14 [[Digits 1]] [])
+      @?= Just (SimplePkg "linux-is-cool" . Ideal $ SemVer 3 2 14 [[Digits 1]] Nothing)
     , testCase "simplepkg'"
-      $ simplepkg' "xchat 2.8.8-19" @?= Just (SimplePkg "xchat" . Ideal $ SemVer 2 8 8 [[Digits 19]] [])
+      $ simplepkg' "xchat 2.8.8-19" @?= Just (SimplePkg "xchat" . Ideal $ SemVer 2 8 8 [[Digits 19]] Nothing)
     ]
   , testGroup "Aura.Packages.Repository"
-    [ testCase "extractVersion" $ extractVersion firefox @?= Just (Ideal $ SemVer 60 0 2 [[Digits 1]] [])
+    [ testCase "extractVersion" $ extractVersion firefox @?= Just (Ideal $ SemVer 60 0 2 [[Digits 1]] Nothing)
     ]
   , testGroup "Aura.Pacman"
     [ testCase "Parsing pacman.conf" $ do

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,3 +17,6 @@ packages:
   - aura/
   - aur/
   - aursec/
+
+extra-deps:
+  - versions-5.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.11
+resolver: lts-17.15
 
 ghc-options:
   $everything: -split-sections -haddock

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: versions-5.0.0@sha256:4c649d7db19ff25f0e659d7009e26645ae68b2c554497ecc2f7bbd361f3671b3,2002
+    pantry-tree:
+      size: 320
+      sha256: a32684587b73170ce7725cd9147e8525c26f7cbf3814d8ee568f5ec9f6e9bbdd
+  original:
+    hackage: versions-5.0.0
 snapshots:
 - completed:
     size: 567679

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 567672
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/11.yaml
-    sha256: 03181cdbeb671eb605bbcf6f285bea4d094b6ac7433a0e14a9f1dd54ad995938
-  original: lts-17.11
+    size: 567679
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/15.yaml
+    sha256: 72e87841a0ab5b72f6f018e8ee692fd972b7bb32a944990f028e10d6eb528e63
+  original: lts-17.15


### PR DESCRIPTION
This PR bumps the lower bound of `versions` to match the newest version (hah) on Hackage.