### PR TITLE
fix(aura): don't recognize `.sig` files as a `PackagePath`

### DIFF
--- a/aura/CHANGELOG.md
+++ b/aura/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Aura Changelog
 
+## Unreleased
+
+#### Fixed
+
+- `.sig` files were appearing in `-C` selection options.
+
 ## 3.2.8 (2022-04-23)
 
 #### Added

--- a/aura/lib/Aura/Types.hs
+++ b/aura/lib/Aura/Types.hs
@@ -245,7 +245,7 @@ instance Ord PackagePath where
 
 -- | Smart constructor for `PackagePath`.
 packagePath :: FilePath -> Maybe PackagePath
-packagePath fp = bool Nothing (Just $ PackagePath fp) $ isAbsolute fp
+packagePath fp = bool Nothing (Just $ PackagePath fp) $ not (isExtensionOf "sig" fp) && isAbsolute fp
 
 -- | The contents of a PKGBUILD file.
 newtype Pkgbuild = Pkgbuild { pkgbuild :: ByteString }


### PR DESCRIPTION
Fixes #763 .