### PR TITLE
Rust Port: Part 4 - Building and Installation

### DIFF
--- a/rust/aura-arch/src/lib.rs
+++ b/rust/aura-arch/src/lib.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_MAKEPKG_CONF: &str = "/etc/makepkg.conf";
 ///
 /// An orphan is a package that was installed as a dependency, but whose parent
 /// package is no longer installed.
-pub fn orphans<'a>(alpm: &'a Alpm) -> impl Iterator<Item = Package<'a>> {
+pub fn orphans(alpm: &Alpm) -> impl Iterator<Item = Package<'_>> {
     alpm.localdb().pkgs().into_iter().filter(|p| {
         p.reason() == PackageReason::Depend
             && p.required_by().is_empty()
@@ -24,7 +24,7 @@ pub fn orphans<'a>(alpm: &'a Alpm) -> impl Iterator<Item = Package<'a>> {
 }
 
 /// All official packages.
-pub fn officials<'a>(alpm: &'a Alpm) -> impl Iterator<Item = Package<'a>> {
+pub fn officials(alpm: &Alpm) -> impl Iterator<Item = Package<'_>> {
     let syncs = alpm.syncdbs();
 
     alpm.localdb()
@@ -34,7 +34,7 @@ pub fn officials<'a>(alpm: &'a Alpm) -> impl Iterator<Item = Package<'a>> {
 }
 
 /// All foreign packages as an `Iterator`.
-pub fn foreigns<'a>(alpm: &'a Alpm) -> impl Iterator<Item = Package<'a>> {
+pub fn foreigns(alpm: &Alpm) -> impl Iterator<Item = Package<'_>> {
     let syncs = alpm.syncdbs();
 
     alpm.localdb()

--- a/rust/aura-core/src/aur/dependencies.rs
+++ b/rust/aura-core/src/aur/dependencies.rs
@@ -125,6 +125,12 @@ impl Borrow<str> for Official {
     }
 }
 
+impl AsRef<str> for Official {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
 impl std::fmt::Display for Official {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)

--- a/rust/aura-core/src/lib.rs
+++ b/rust/aura-core/src/lib.rs
@@ -104,7 +104,7 @@ where
     P: AsRef<Path>,
 {
     paths
-        .into_iter()
+        .iter()
         .filter_map(|path| path.as_ref().read_dir().ok())
         .flatten()
 }

--- a/rust/aura/src/command/aur/build.rs
+++ b/rust/aura/src/command/aur/build.rs
@@ -162,7 +162,7 @@ fn copy_to_cache(cache: &Path, tarballs: &[PathBuf]) -> Result<Vec<PathBuf>, Err
                 .ok_or_else(|| Error::FilenameExtraction(tarball.clone()))
                 .and_then(|file| {
                     let target = [cache, file.as_ref()].iter().collect::<PathBuf>();
-                    move_tarball(&tarball, &target).map(|_| target)
+                    move_tarball(tarball, &target).map(|_| target)
                 })
         })
         .collect::<Result<Vec<PathBuf>, Error>>()

--- a/rust/aura/src/command/aur/build.rs
+++ b/rust/aura/src/command/aur/build.rs
@@ -136,6 +136,7 @@ fn makepkg(within: &Path) -> Result<Vec<PathBuf>, Error> {
         .then(|| ())
         .ok_or(Error::Makepkg)?;
 
+    // NOTE Outputs absolute paths.
     let bytes = Command::new("makepkg")
         .arg("--packagelist")
         .current_dir(within)

--- a/rust/aura/src/command/cache.rs
+++ b/rust/aura/src/command/cache.rs
@@ -1,7 +1,7 @@
 //! All functionality involving the `-C` command.
 
 use crate::download::download_with_progress;
-use crate::{a, aura, green, red, yellow};
+use crate::{aura, green, red, yellow};
 use alpm::Alpm;
 use aura_core::cache::{CacheSize, PkgPath};
 use chrono::{DateTime, Local};
@@ -78,7 +78,7 @@ pub(crate) fn downgrade(
     let mut to_downgrade: Vec<OsString> = packages
         .iter()
         .filter_map(|p| tarballs.remove(p.as_str()).map(|pps| (p, pps)))
-        .filter_map(|(p, pps)| downgrade_one(fll, &p, pps).ok())
+        .filter_map(|(p, pps)| downgrade_one(fll, p, pps).ok())
         .map(|pp| pp.into_pathbuf().into_os_string())
         .collect();
 
@@ -231,11 +231,10 @@ pub(crate) fn clean(
 
     // Get all the tarball paths, sort and group them by name, and then remove them.
     aura_core::cache::package_paths(caches)
-        .sorted_by(|p0, p1| p1.cmp(&p0)) // Forces a `collect` underneath.
+        .sorted_by(|p0, p1| p1.cmp(p0)) // Forces a `collect` underneath.
         .group_by(|pp| pp.as_package().name.clone()) // TODO Naughty clone.
         .into_iter()
-        .map(|(_, group)| group.skip(keep)) // Thanks to the reverse-sort above, `group` is already backwards.
-        .flatten()
+        .flat_map(|(_, group)| group.skip(keep)) // Thanks to the reverse-sort above, `group` is already backwards.
         .for_each(|pp| {
             let _ = pp.remove(); // TODO Handle this error better?
         });

--- a/rust/aura/src/command/orphans.rs
+++ b/rust/aura/src/command/orphans.rs
@@ -1,12 +1,11 @@
 //! All functionality involving the `-O` command.
 
-use crate::{a, green, yellow};
+use crate::{green, yellow};
 use alpm::{Alpm, PackageReason, TransFlag};
 use aura_arch as arch;
 use colored::*;
 use from_variants::FromVariants;
 use i18n_embed::fluent::FluentLanguageLoader;
-use i18n_embed_fl::fl;
 use std::collections::HashSet;
 use ubyte::ToByteUnit;
 
@@ -33,7 +32,7 @@ impl std::fmt::Display for Error {
 
 /// Print the name of each orphaned package.
 pub(crate) fn list(alpm: &Alpm) {
-    arch::orphans(&alpm).for_each(|o| println!("{}", o.name()))
+    arch::orphans(alpm).for_each(|o| println!("{}", o.name()))
 }
 
 /// Sets a package's install reason to "as explicit". An alias for `-D --asexplicit`.

--- a/rust/aura/src/command/snapshot.rs
+++ b/rust/aura/src/command/snapshot.rs
@@ -136,6 +136,7 @@ fn restore_snapshot(alpm: &Alpm, caches: &[&Path], snapshot: Snapshot) -> Result
 
     // Alter packages first to avoid potential breakage from the later removal
     // step.
+    let nothing: [&str; 0] = [];
     if diff.to_add_or_alter.is_empty().not() {
         let tarballs = aura_core::cache::package_paths(caches)
             .filter(|pp| {
@@ -147,12 +148,12 @@ fn restore_snapshot(alpm: &Alpm, caches: &[&Path], snapshot: Snapshot) -> Result
             })
             .map(|pp| pp.into_pathbuf().into_os_string());
 
-        crate::pacman::sudo_pacman("-U", tarballs)?;
+        crate::pacman::sudo_pacman("-U", nothing, tarballs)?;
     }
 
     // Remove packages that weren't installed within the chosen snapshot.
     if diff.to_remove.is_empty().not() {
-        crate::pacman::sudo_pacman("-R", diff.to_remove)?;
+        crate::pacman::sudo_pacman("-R", nothing, diff.to_remove)?;
     }
 
     Ok(())

--- a/rust/aura/src/command/snapshot.rs
+++ b/rust/aura/src/command/snapshot.rs
@@ -7,12 +7,12 @@ use colored::*;
 use from_variants::FromVariants;
 use i18n_embed::fluent::FluentLanguageLoader;
 use i18n_embed_fl::fl;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufWriter;
 use std::ops::Not;
 use std::path::Path;
-use std::{cmp::Ordering, ffi::OsStr};
 
 #[derive(FromVariants)]
 pub enum Error {

--- a/rust/aura/src/command/snapshot.rs
+++ b/rust/aura/src/command/snapshot.rs
@@ -147,14 +147,12 @@ fn restore_snapshot(alpm: &Alpm, caches: &[&Path], snapshot: Snapshot) -> Result
             })
             .map(|pp| pp.into_pathbuf().into_os_string());
 
-        crate::pacman::sudo_pacman(
-            std::iter::once(OsStr::new("-U").to_os_string()).chain(tarballs),
-        )?;
+        crate::pacman::sudo_pacman("-U", tarballs)?;
     }
 
     // Remove packages that weren't installed within the chosen snapshot.
     if diff.to_remove.is_empty().not() {
-        crate::pacman::sudo_pacman(std::iter::once("-R").chain(diff.to_remove))?;
+        crate::pacman::sudo_pacman("-R", diff.to_remove)?;
     }
 
     Ok(())

--- a/rust/aura/src/pacman.rs
+++ b/rust/aura/src/pacman.rs
@@ -54,7 +54,7 @@ where
 }
 
 /// Call `sudo pacman -U`.
-pub(crate) fn pacman_install_from_tarball<'a, I, S>(args: I) -> Result<(), Error>
+pub(crate) fn pacman_install_from_tarball<I, S>(args: I) -> Result<(), Error>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,

--- a/rust/aura/src/pacman.rs
+++ b/rust/aura/src/pacman.rs
@@ -38,13 +38,14 @@ where
 }
 
 /// Make an elevated shell call to `pacman`.
-pub(crate) fn sudo_pacman<I, S>(args: I) -> Result<(), Error>
+pub(crate) fn sudo_pacman<I, S>(command: &str, args: I) -> Result<(), Error>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
     Command::new("sudo")
         .arg("pacman")
+        .arg(command)
         .args(args)
         .status()?
         .success()
@@ -53,12 +54,12 @@ where
 }
 
 /// Call `sudo pacman -U`.
-pub(crate) fn pacman_install_from_tarball<'a, I>(args: I) -> Result<(), Error>
+pub(crate) fn pacman_install_from_tarball<'a, I, S>(args: I) -> Result<(), Error>
 where
-    I: IntoIterator<Item = &'a str>,
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
 {
-    let iter = std::iter::once("-U").chain(args);
-    sudo_pacman(iter).map_err(|_| Error::InstallFromTarball)
+    sudo_pacman("-U", args).map_err(|_| Error::InstallFromTarball)
 }
 
 /// Call `sudo pacman -S`.
@@ -66,6 +67,5 @@ pub(crate) fn pacman_install_from_repos<'a, I>(args: I) -> Result<(), Error>
 where
     I: IntoIterator<Item = &'a str>,
 {
-    let iter = std::iter::once("-S").chain(args);
-    sudo_pacman(iter).map_err(|_| Error::InstallFromRepos)
+    sudo_pacman("-S", args).map_err(|_| Error::InstallFromRepos)
 }

--- a/rust/aura/src/pacman.rs
+++ b/rust/aura/src/pacman.rs
@@ -38,14 +38,17 @@ where
 }
 
 /// Make an elevated shell call to `pacman`.
-pub(crate) fn sudo_pacman<I, S>(command: &str, args: I) -> Result<(), Error>
+pub(crate) fn sudo_pacman<I, J, S, T>(command: &str, flags: I, args: J) -> Result<(), Error>
 where
     I: IntoIterator<Item = S>,
+    J: IntoIterator<Item = T>,
     S: AsRef<OsStr>,
+    T: AsRef<OsStr>,
 {
     Command::new("sudo")
         .arg("pacman")
         .arg(command)
+        .args(flags)
         .args(args)
         .status()?
         .success()
@@ -54,18 +57,23 @@ where
 }
 
 /// Call `sudo pacman -U`.
-pub(crate) fn pacman_install_from_tarball<I, S>(args: I) -> Result<(), Error>
+pub(crate) fn pacman_install_from_tarball<I, J, S, T>(flags: I, args: J) -> Result<(), Error>
 where
     I: IntoIterator<Item = S>,
+    J: IntoIterator<Item = T>,
     S: AsRef<OsStr>,
+    T: AsRef<OsStr>,
 {
-    sudo_pacman("-U", args).map_err(|_| Error::InstallFromTarball)
+    sudo_pacman("-U", flags, args).map_err(|_| Error::InstallFromTarball)
 }
 
 /// Call `sudo pacman -S`.
-pub(crate) fn pacman_install_from_repos<'a, I>(args: I) -> Result<(), Error>
+pub(crate) fn pacman_install_from_repos<I, J, S, T>(flags: I, args: J) -> Result<(), Error>
 where
-    I: IntoIterator<Item = &'a str>,
+    I: IntoIterator<Item = S>,
+    J: IntoIterator<Item = T>,
+    S: AsRef<OsStr>,
+    T: AsRef<OsStr>,
 {
-    sudo_pacman("-S", args).map_err(|_| Error::InstallFromRepos)
+    sudo_pacman("-S", flags, args).map_err(|_| Error::InstallFromRepos)
 }


### PR DESCRIPTION
This PR continues the Rust porting work. Tiers of packages can be built and installed such that dependencies are always handled first, and building is done in batches.