### PR TITLE
Rust Port: Part 7 - Hotediting

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -58,7 +58,6 @@ dependencies = [
  "from_variants",
  "i18n-embed",
  "i18n-embed-fl",
- "is_executable",
  "itertools",
  "linya",
  "log",
@@ -761,15 +760,6 @@ name = "io-lifetimes"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
-
-[[package]]
-name = "is_executable"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "itertools"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "unic-langid",
  "validated",
  "webbrowser",
+ "which",
 ]
 
 [[package]]
@@ -1848,6 +1849,17 @@ dependencies = [
  "web-sys",
  "widestring",
  "winapi",
+]
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/rust/aura/Cargo.toml
+++ b/rust/aura/Cargo.toml
@@ -41,6 +41,7 @@ ubyte = "0.10"
 unic-langid = { version = "0.9", features = ["macros"] }
 validated = { version = "0.1", features = ["rayon"] }
 webbrowser = "0.7"
+which = "4.2"
 
 [features]
 git = ["alpm/git"]

--- a/rust/aura/Cargo.toml
+++ b/rust/aura/Cargo.toml
@@ -19,7 +19,6 @@ curl = "0.4"
 from_variants = "1.0"
 i18n-embed = { version = "0.13", features = ["fluent-system"] }
 i18n-embed-fl = "0.6"
-is_executable = "1.0"
 itertools = "0.10"
 linya = "0.3"
 log = "0.4"

--- a/rust/aura/i18n/en-US/aura.ftl
+++ b/rust/aura/i18n/en-US/aura.ftl
@@ -91,13 +91,17 @@ L-recent = Recent Actions
 
 # System Validation (check)
 check-start = Validating your system.
+check-missing-exec = Fix: Please install { $exec } and/or ensure it's on your PATH.
+check-env = Environment
+check-env-editor = EDITOR variable set?
+check-env-editor-exec = EDITOR value ({ $exec }) is executable?
+check-env-editor-vi = Backup editor vi is executable?
 check-conf = Pacman & Makepkg Configuration
 check-conf-parallel = Parallel downloads activated?
 check-conf-parallel-fix = Your { $setting } setting is off, or set to 1. Is that intended?
 check-conf-ignores = No overlapping ignored packages?
 check-conf-ignores-fix = The following packages are ignored in both pacman.conf and aura.toml: { $pkgs }
 check-conf-pacnew = All .pacnew files accounted for?
-check-conf-pacnew-fd = Fix: Please install { $fd }.
 check-conf-pacnew-broken = Error: Call to { $fd } utterly failed.
 check-conf-pacnew-old = { $path } is older than its .pacnew by { $days } days.
 check-snapshots = Package Snapshots

--- a/rust/aura/i18n/en-US/aura.ftl
+++ b/rust/aura/i18n/en-US/aura.ftl
@@ -10,8 +10,8 @@ A-install-aur-pkgs = AUR packages:
 
 A-build-prep = Preparing build directories...
 A-build-pkg = Building { $pkg }...
-# hotEdit_1
-A-build-hotedit-pkgbuild = Would you like to edit the PKGBUILD?
+A-build-hotedit-pkgbuild = Edit the PKGBUILD?
+A-build-hotedit-install = Edit the .install file?
 A-build-fail = Package failed to build, citing:
 
 A-i-repo = Repository

--- a/rust/aura/i18n/en-US/aura.ftl
+++ b/rust/aura/i18n/en-US/aura.ftl
@@ -9,6 +9,9 @@ A-install-repo-pkgs = Repository dependencies:
 A-install-aur-pkgs = AUR packages:
 
 A-build-prep = Preparing build directories...
+A-build-pkg = Building { $pkg }...
+# hotEdit_1
+A-build-hotedit-pkgbuild = Would you like to edit the PKGBUILD?
 A-build-fail = Package failed to build, citing:
 
 A-i-repo = Repository

--- a/rust/aura/i18n/en-US/aura.ftl
+++ b/rust/aura/i18n/en-US/aura.ftl
@@ -96,6 +96,7 @@ check-env = Environment
 check-env-editor = EDITOR variable set?
 check-env-editor-exec = EDITOR value ({ $exec }) is executable?
 check-env-editor-vi = Backup editor vi is executable?
+check-env-installed = { $exec } installed and executable?
 check-conf = Pacman & Makepkg Configuration
 check-conf-parallel = Parallel downloads activated?
 check-conf-parallel-fix = Your { $setting } setting is off, or set to 1. Is that intended?

--- a/rust/aura/i18n/en-US/aura.ftl
+++ b/rust/aura/i18n/en-US/aura.ftl
@@ -115,7 +115,7 @@ check-cache-exists = All specified caches exist?
 check-cache-tarballs = All tarballs valid?
 check-cache-tarballs-fix = Fix: You can remove invalid tarballs with { $command }
 check-cache-missing = Every installed package has a tarball?
-check-cache-missing-fix = Fix: You can download missing tarballs with { $command }
+check-cache-missing-fix = Fix: You can download missing official tarballs with { $command }
 
 # Common Fields
 common-yes = Yes

--- a/rust/aura/src/command/aur/build.rs
+++ b/rust/aura/src/command/aur/build.rs
@@ -133,7 +133,7 @@ fn build_one(
         .map_err(Error::Copies)?;
 
     if hotedit {
-        overwrite_build_files(fll, editor, &build)?;
+        overwrite_build_files(fll, editor, &build, &base)?;
     }
 
     let tarballs = makepkg(&build)?;
@@ -148,11 +148,26 @@ fn overwrite_build_files(
     fll: &FluentLanguageLoader,
     editor: &str,
     build_d: &Path,
+    pkgbase: &str,
 ) -> Result<(), Error> {
+    // --- Edit the PKGBUILD in-place --- //
     if proceed!(fll, "A-build-hotedit-pkgbuild").is_some() {
         let pkgbuild = build_d.join("PKGBUILD");
         edit(editor, pkgbuild)?;
     }
+
+    // --- Edit the post-build `.install` file, if there is one --- //
+    let install = {
+        let mut install = build_d.join(pkgbase);
+        install.set_extension("install");
+        install
+    };
+
+    if install.is_file() && proceed!(fll, "A-build-hotedit-install").is_some() {
+        edit(editor, install)?;
+    }
+
+    // --- Edit any available .patch files --- //
 
     Ok(())
 }

--- a/rust/aura/src/command/aur/build.rs
+++ b/rust/aura/src/command/aur/build.rs
@@ -168,6 +168,13 @@ fn overwrite_build_files(
     }
 
     // --- Edit any available .patch files --- //
+    build_d
+        .read_dir()?
+        .filter_map(|de| de.ok())
+        .map(|de| de.path())
+        .filter(|path| path.extension() == Some("patch".as_ref()))
+        .map(|path| edit(editor, path))
+        .collect::<Result<(), Error>>()?;
 
     Ok(())
 }

--- a/rust/aura/src/command/cache.rs
+++ b/rust/aura/src/command/cache.rs
@@ -2,7 +2,7 @@
 
 use crate::download::download_with_progress;
 use crate::env::Env;
-use crate::{aura, green, red, yellow};
+use crate::{aura, green, proceed, red, yellow};
 use alpm::Alpm;
 use aura_core::cache::{CacheSize, PkgPath};
 use chrono::{DateTime, Local};
@@ -226,9 +226,7 @@ pub(crate) fn clean(
     yellow!(fll, "C-c-keep", pkgs = keep);
 
     // Proceed if the user accepts.
-    crate::utils::proceed(fll)
-        .then(|| ())
-        .ok_or(Error::Cancelled)?;
+    proceed!(fll, "proceed").ok_or(Error::Cancelled)?;
 
     // Get all the tarball paths, sort and group them by name, and then remove them.
     aura_core::cache::package_paths(caches)
@@ -256,9 +254,7 @@ pub(crate) fn clean_not_saved(fll: &FluentLanguageLoader, env: &Env) -> Result<(
     aura!(fll, "C-size", size = human);
 
     // Proceed if the user accepts.
-    crate::utils::proceed(fll)
-        .then(|| ())
-        .ok_or(Error::Cancelled)?;
+    proceed!(fll, "proceed").ok_or(Error::Cancelled)?;
 
     let tarballs = aura_core::cache::package_paths(&caches);
 
@@ -343,9 +339,7 @@ pub(crate) fn refresh(
         );
 
         // Proceed if the user accepts.
-        crate::utils::proceed(fll)
-            .then(|| ())
-            .ok_or(Error::Cancelled)?;
+        proceed!(fll, "proceed").ok_or(Error::Cancelled)?;
 
         // Determine target cache.
         aura!(fll, "C-y-which-cache");
@@ -464,9 +458,7 @@ pub(crate) fn backup(fll: &FluentLanguageLoader, env: &Env, target: &Path) -> Re
     }
 
     // Proceed if the user accepts.
-    crate::utils::proceed(fll)
-        .then(|| ())
-        .ok_or(Error::Cancelled)?;
+    proceed!(fll, "proceed").ok_or(Error::Cancelled)?;
 
     copy(&sources, &full, cache_size.files)
 }

--- a/rust/aura/src/command/check.rs
+++ b/rust/aura/src/command/check.rs
@@ -55,6 +55,9 @@ pub(crate) fn check(fll: &FluentLanguageLoader, env: &Env) -> Result<(), Error> 
 fn environment(fll: &FluentLanguageLoader) {
     aura!(fll, "check-env");
     editor(fll);
+    executable!(fll, "git", "check-env-installed", exec = "git");
+    executable!(fll, "fd", "check-env-installed", exec = "fd");
+    executable!(fll, "diff", "check-env-installed", exec = "diff");
 }
 
 fn editor(fll: &FluentLanguageLoader) {

--- a/rust/aura/src/command/check.rs
+++ b/rust/aura/src/command/check.rs
@@ -7,7 +7,6 @@ use colored::*;
 use from_variants::FromVariants;
 use i18n_embed::fluent::FluentLanguageLoader;
 use i18n_embed_fl::fl;
-use is_executable::IsExecutable;
 use r2d2::Pool;
 use r2d2_alpm::AlpmManager;
 use rayon::prelude::*;
@@ -202,20 +201,19 @@ fn packages_have_tarballs(fll: &FluentLanguageLoader, alpm: &Alpm, caches: &[&Pa
 }
 
 fn pacnews(fll: &FluentLanguageLoader) {
-    let fd_installed = Path::new("/bin/fd").is_executable();
-
-    if !fd_installed {
-        println!(
-            "  [{}] {}",
-            CANCEL.truecolor(128, 128, 128),
-            fl!(fll, "check-conf-pacnew")
-        );
-        println!(
-            "      └─ {}",
-            fl!(fll, "check-missing-exec", exec = "fd".cyan().to_string())
-        );
-    } else {
-        match pacnew_work() {
+    match which::which("fd") {
+        Err(_) => {
+            println!(
+                "  [{}] {}",
+                CANCEL.truecolor(128, 128, 128),
+                fl!(fll, "check-conf-pacnew")
+            );
+            println!(
+                "      └─ {}",
+                fl!(fll, "check-missing-exec", exec = "fd".cyan().to_string())
+            );
+        }
+        Ok(_) => match pacnew_work() {
             None => {
                 println!(
                     "  [{}] {}",
@@ -252,7 +250,7 @@ fn pacnews(fll: &FluentLanguageLoader) {
                     );
                 }
             }
-        }
+        },
     }
 }
 

--- a/rust/aura/src/command/orphans.rs
+++ b/rust/aura/src/command/orphans.rs
@@ -1,6 +1,6 @@
 //! All functionality involving the `-O` command.
 
-use crate::{green, yellow};
+use crate::{green, proceed, yellow};
 use alpm::{Alpm, PackageReason, TransFlag};
 use aura_arch as arch;
 use colored::*;
@@ -107,9 +107,7 @@ pub(crate) fn remove(alpm: &mut Alpm, fll: FluentLanguageLoader) -> Result<(), E
         println!("  {:w$} {:>9}\n", "Total", size, w = longest);
 
         // Proceed with the removal if the user accepts.
-        crate::utils::proceed(&fll)
-            .then(|| ())
-            .ok_or(Error::Cancelled)?;
+        proceed!(fll, "proceed").ok_or(Error::Cancelled)?;
 
         alpm.trans_commit().map_err(|(_, e)| Error::Alpm(e))?;
         alpm.trans_release()?;

--- a/rust/aura/src/command/snapshot.rs
+++ b/rust/aura/src/command/snapshot.rs
@@ -1,12 +1,11 @@
 //! All functionality involving the `-B` command.
 
-use crate::{a, aura, green, red};
+use crate::{aura, green, proceed, red};
 use alpm::Alpm;
 use aura_core::snapshot::Snapshot;
 use colored::*;
 use from_variants::FromVariants;
 use i18n_embed::fluent::FluentLanguageLoader;
-use i18n_embed_fl::fl;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -68,8 +67,7 @@ pub(crate) fn clean(
     caches: &[&Path],
     snapshots: &Path,
 ) -> Result<(), Error> {
-    let msg = format!("{} {} ", fl!(fll, "B-clean"), fl!(fll, "proceed-yes"));
-    crate::utils::prompt(&a!(msg)).ok_or(Error::Cancelled)?;
+    proceed!(fll, "B-clean").ok_or(Error::Cancelled)?;
     let vers = aura_core::cache::all_versions(caches);
 
     for (path, snapshot) in aura_core::snapshot::snapshots_with_paths(snapshots) {

--- a/rust/aura/src/env.rs
+++ b/rust/aura/src/env.rs
@@ -18,6 +18,7 @@ pub(crate) enum Error {
     Env(std::env::VarError),
     Io(std::io::Error),
     Toml(toml::de::Error),
+    MissingEditor,
 }
 
 impl std::fmt::Display for Error {
@@ -28,6 +29,7 @@ impl std::fmt::Display for Error {
             Error::Env(e) => write!(f, "{e}"),
             Error::Io(e) => write!(f, "{e}"),
             Error::Toml(e) => write!(f, "{e}"),
+            Error::MissingEditor => write!(f, "Provided EDITOR is not on the PATH!"),
         }
     }
 }
@@ -120,6 +122,15 @@ impl Env {
             crate::flags::SubCmd::Aur(a) => self.aur.reconcile(a),
             _ => {}
         }
+    }
+
+    /// Before continuing, confirm that the settled `Env` is valid to use.
+    pub(crate) fn validate(&self) -> Result<(), Error> {
+        if self.aur.hotedit {
+            which::which(&self.general.editor).map_err(|_| Error::MissingEditor)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/rust/aura/src/env.rs
+++ b/rust/aura/src/env.rs
@@ -160,6 +160,8 @@ struct RawAur {
     ignores: HashSet<String>,
     #[serde(default)]
     git: bool,
+    #[serde(default)]
+    hotedit: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -170,6 +172,8 @@ pub(crate) struct Aur {
     pub(crate) ignores: HashSet<String>,
     /// Always rebuild VCS packages with `-Au`?
     pub(crate) git: bool,
+    /// View/edit PKGBUILDs (etc.) before building.
+    pub(crate) hotedit: bool,
 }
 
 impl Aur {
@@ -181,14 +185,21 @@ impl Aur {
             clones: dirs::clones()?,
             ignores: HashSet::new(),
             git: false,
+            hotedit: false,
         };
 
         Ok(a)
     }
 
+    /// Flags set on the command line should override config settings and other
+    /// defaults.
     fn reconcile(&mut self, flags: &crate::flags::Aur) {
         if flags.git {
             self.git = true;
+        }
+
+        if flags.hotedit {
+            self.hotedit = true;
         }
 
         // Harmless clone, as we don't expect many "ignores" to be passed on the
@@ -211,6 +222,7 @@ impl TryFrom<RawAur> for Aur {
             clones,
             ignores: raw.ignores,
             git: raw.git,
+            hotedit: raw.hotedit,
         };
 
         Ok(a)

--- a/rust/aura/src/flags.rs
+++ b/rust/aura/src/flags.rs
@@ -764,6 +764,10 @@ pub(crate) struct Aur {
     #[clap(group = "aur", long, short, value_name = "package", display_order = 1)]
     pub(crate) pkgbuild: Option<String>,
 
+    /// View/edit PKGBUILDs and related build files before building.
+    #[clap(long, display_order = 4)]
+    pub(crate) hotedit: bool,
+
     /// Upgrade all installed AUR packages.
     #[clap(group = "aur", long, short = 'u', display_order = 1)]
     pub(crate) sysupgrade: bool,

--- a/rust/aura/src/macros.rs
+++ b/rust/aura/src/macros.rs
@@ -59,3 +59,39 @@ macro_rules! red {
         $crate::aln!(i18n_embed_fl::fl!($fll, $msg).red());
     };
 }
+
+#[macro_export]
+/// Detect an executable or warn if it's missing.
+///
+/// Used by the `check` module.
+macro_rules! executable {
+    ($fll:expr, $exec:expr, $msg:expr, $($arg:expr),*) => {
+        let good = which::which($exec).is_ok();
+        let symb = if good { crate::command::check::GOOD.green() } else { crate::command::check::BAD.red() };
+        println!(
+            "  [{}] {}",
+            symb,
+            i18n_embed_fl::fl!($fll, $msg, $($arg)*)
+        );
+
+        if !good {
+            let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().to_string());
+            println!("      └─ {}", msg);
+        }
+    };
+    ($fll:expr, $exec:expr, $msg:expr) => {
+        let good = which::which($exec).is_ok();
+        let symb = if good { crate::command::check::GOOD.green() } else { crate::command::check::BAD.red() };
+        println!(
+            "  [{}] {}",
+            symb,
+            i18n_embed_fl::fl!($fll, $msg)
+        );
+
+        if !good {
+            let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().to_string());
+            println!("      └─ {}", msg);
+        }
+
+    };
+}

--- a/rust/aura/src/macros.rs
+++ b/rust/aura/src/macros.rs
@@ -92,6 +92,18 @@ macro_rules! executable {
             let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().bold().to_string());
             println!("      └─ {}", msg);
         }
-
     };
+}
+
+#[macro_export]
+/// Ask for permission to proceed, but with a custom message.
+macro_rules! proceed {
+    ($fll:expr, $msg:expr) => {{
+        let foo = format!(
+            "{} {} ",
+            i18n_embed_fl::fl!($fll, $msg),
+            i18n_embed_fl::fl!($fll, "proceed-yes")
+        );
+        crate::utils::prompt(&$crate::a!(foo))
+    }};
 }

--- a/rust/aura/src/macros.rs
+++ b/rust/aura/src/macros.rs
@@ -75,7 +75,7 @@ macro_rules! executable {
         );
 
         if !good {
-            let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().to_string());
+            let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().bold().to_string());
             println!("      └─ {}", msg);
         }
     };
@@ -89,7 +89,7 @@ macro_rules! executable {
         );
 
         if !good {
-            let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().to_string());
+            let msg = fl!($fll, "check-missing-exec", exec = $exec.cyan().bold().to_string());
             println!("      └─ {}", msg);
         }
 

--- a/rust/aura/src/main.rs
+++ b/rust/aura/src/main.rs
@@ -53,6 +53,7 @@ fn work(args: Args) -> Result<(), Error> {
     let env = {
         let mut env = crate::env::Env::try_new()?;
         env.reconcile_cli(&args.subcmd);
+        env.validate()?;
         env
     };
     debug!("{:#?}", env);

--- a/rust/aura/src/utils.rs
+++ b/rust/aura/src/utils.rs
@@ -1,9 +1,6 @@
 //! Various utility functions.
 
-use crate::a;
 use colored::{ColoredString, Colorize};
-use i18n_embed::fluent::FluentLanguageLoader;
-use i18n_embed_fl::fl;
 use rustyline::Editor;
 use std::io::Write;
 use std::str::FromStr;
@@ -74,12 +71,6 @@ pub(crate) fn prompt(msg: &str) -> Option<()> {
     let line = rl.readline(msg).ok()?;
 
     (line.is_empty() || line == "y" || line == "Y").then(|| ())
-}
-
-/// Only proceed if the user agrees.
-pub(crate) fn proceed(fll: &FluentLanguageLoader) -> bool {
-    let msg = format!("{} {} ", fl!(fll, "proceed"), fl!(fll, "proceed-yes"));
-    prompt(&a!(msg)).is_some()
 }
 
 /// Prompt the user for a numerical selection.


### PR DESCRIPTION
This PR enables the `--hotedit` flag for use with `-A`. It can also be turned on permanently via config.