### PR TITLE
Rust Port: Part 8 - Build file Diffing

### DIFF
--- a/rust/aura-core/src/lib.rs
+++ b/rust/aura-core/src/lib.rs
@@ -122,7 +122,8 @@ where
 }
 
 /// Apply functions in method-position.
-pub(crate) trait Apply {
+pub trait Apply {
+    /// Apply a given function in method-position.
     fn apply<F, U>(self, f: F) -> U
     where
         F: FnOnce(Self) -> U,

--- a/rust/aura/i18n/en-US/aura.ftl
+++ b/rust/aura/i18n/en-US/aura.ftl
@@ -10,6 +10,7 @@ A-install-aur-pkgs = AUR packages:
 
 A-build-prep = Preparing build directories...
 A-build-pkg = Building { $pkg }...
+A-build-diff = Display diffs of build files?
 A-build-hotedit-pkgbuild = Edit the PKGBUILD?
 A-build-hotedit-install = Edit the .install file?
 A-build-fail = Package failed to build, citing:

--- a/rust/aura/src/command/aur.rs
+++ b/rust/aura/src/command/aur.rs
@@ -397,6 +397,8 @@ where
             fll,
             &env.aur.cache,
             &env.aur.build,
+            &env.aur.hashes,
+            env.aur.diff,
             env.aur.hotedit,
             &env.general.editor,
             clone_paths,
@@ -417,14 +419,6 @@ where
 
     green!(fll, "common-done");
     Ok(())
-}
-
-/// What AUR repo git hash is associated with the last time a given package was
-/// installed?
-fn hash_of_last_install(hashes: &Path, pkgbase: &str) -> Result<String, Error> {
-    let path = hashes.join(pkgbase);
-    let hash = aura_core::git::hash(&path)?;
-    Ok(hash)
 }
 
 fn update_hash(hashes: &Path, clone: &Path) -> Result<(), Error> {

--- a/rust/aura/src/command/aur.rs
+++ b/rust/aura/src/command/aur.rs
@@ -392,17 +392,8 @@ where
     let len = order.len();
     for (i, layer) in order.into_iter().enumerate() {
         let clone_paths = layer.into_iter().map(|pkg| env.aur.clones.join(pkg));
+        let builts = build::build(fll, &env.aur, &env.general.editor, clone_paths)?;
 
-        let builts = build::build(
-            fll,
-            &env.aur.cache,
-            &env.aur.build,
-            &env.aur.hashes,
-            env.aur.diff,
-            env.aur.hotedit,
-            &env.general.editor,
-            clone_paths,
-        )?;
         if builts.is_empty().not() {
             let flags = (i + 1 < len)
                 .then(|| ["--asdeps"].as_slice())

--- a/rust/aura/src/command/aur.rs
+++ b/rust/aura/src/command/aur.rs
@@ -388,7 +388,7 @@ where
     for (i, layer) in order.into_iter().enumerate() {
         let clone_paths = layer.into_iter().map(|pkg| env.aur.clones.join(pkg));
 
-        let tarballs = build::build(
+        let builts = build::build(
             fll,
             &env.aur.cache,
             &env.aur.build,
@@ -396,10 +396,11 @@ where
             &env.general.editor,
             clone_paths,
         )?;
-        if tarballs.is_empty().not() {
+        if builts.is_empty().not() {
             let flags = (i + 1 < len)
                 .then(|| ["--asdeps"].as_slice())
                 .unwrap_or_default();
+            let tarballs = builts.iter().flat_map(|b| &b.tarballs);
             crate::pacman::pacman_install_from_tarball(flags, tarballs)?;
         }
     }

--- a/rust/aura/src/dirs.rs
+++ b/rust/aura/src/dirs.rs
@@ -102,3 +102,17 @@ pub(crate) fn tarballs() -> Result<PathBuf, Error> {
 
     Ok(path)
 }
+
+/// The full path to the directory of git hashes that indicate the last time an
+/// AUR package was built and installed.
+///
+/// Creates the directory if it doesn't exist.
+pub(crate) fn hashes() -> Result<PathBuf, Error> {
+    let path = aura_xdg_cache()?.join("hashes");
+
+    if path.is_dir().not() {
+        std::fs::create_dir_all(&path)?;
+    }
+
+    Ok(path)
+}

--- a/rust/aura/src/env.rs
+++ b/rust/aura/src/env.rs
@@ -181,6 +181,8 @@ struct RawAur {
     git: bool,
     #[serde(default)]
     hotedit: bool,
+    #[serde(default)]
+    diff: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -194,6 +196,8 @@ pub(crate) struct Aur {
     pub(crate) git: bool,
     /// View/edit PKGBUILDs (etc.) before building.
     pub(crate) hotedit: bool,
+    /// View diffs of PKGBUILDs (etc.) before building.
+    pub(crate) diff: bool,
 }
 
 impl Aur {
@@ -207,6 +211,7 @@ impl Aur {
             ignores: HashSet::new(),
             git: false,
             hotedit: false,
+            diff: false,
         };
 
         Ok(a)
@@ -221,6 +226,10 @@ impl Aur {
 
         if flags.hotedit {
             self.hotedit = true;
+        }
+
+        if flags.diff {
+            self.diff = true;
         }
 
         // Harmless clone, as we don't expect many "ignores" to be passed on the
@@ -246,6 +255,7 @@ impl TryFrom<RawAur> for Aur {
             ignores: raw.ignores,
             git: raw.git,
             hotedit: raw.hotedit,
+            diff: raw.diff,
         };
 
         Ok(a)

--- a/rust/aura/src/env.rs
+++ b/rust/aura/src/env.rs
@@ -174,6 +174,7 @@ struct RawAur {
     build: Option<PathBuf>,
     cache: Option<PathBuf>,
     clones: Option<PathBuf>,
+    hashes: Option<PathBuf>,
     #[serde(default)]
     ignores: HashSet<String>,
     #[serde(default)]
@@ -187,6 +188,7 @@ pub(crate) struct Aur {
     pub(crate) build: PathBuf,
     pub(crate) cache: PathBuf,
     pub(crate) clones: PathBuf,
+    pub(crate) hashes: PathBuf,
     pub(crate) ignores: HashSet<String>,
     /// Always rebuild VCS packages with `-Au`?
     pub(crate) git: bool,
@@ -201,6 +203,7 @@ impl Aur {
             build: dirs::builds()?,
             cache: dirs::tarballs()?,
             clones: dirs::clones()?,
+            hashes: dirs::hashes()?,
             ignores: HashSet::new(),
             git: false,
             hotedit: false,
@@ -233,11 +236,13 @@ impl TryFrom<RawAur> for Aur {
         let build = raw.build.map(Ok).unwrap_or_else(dirs::builds)?;
         let cache = raw.cache.map(Ok).unwrap_or_else(dirs::tarballs)?;
         let clones = raw.clones.map(Ok).unwrap_or_else(dirs::clones)?;
+        let hashes = raw.hashes.map(Ok).unwrap_or_else(dirs::hashes)?;
 
         let a = Aur {
             build,
             cache,
             clones,
+            hashes,
             ignores: raw.ignores,
             git: raw.git,
             hotedit: raw.hotedit,

--- a/rust/aura/src/flags.rs
+++ b/rust/aura/src/flags.rs
@@ -768,6 +768,10 @@ pub(crate) struct Aur {
     #[clap(long, display_order = 4)]
     pub(crate) hotedit: bool,
 
+    /// View diffs of PKGBUILDs and related build files before building.
+    #[clap(long, short = 'k', display_order = 4)]
+    pub(crate) diff: bool,
+
     /// Upgrade all installed AUR packages.
     #[clap(group = "aur", long, short = 'u', display_order = 1)]
     pub(crate) sysupgrade: bool,


### PR DESCRIPTION
This PR restores the functionality of `-Ak`, while extending its functionality to encompass everything that changed from install to install, not just the PKGBUILD.