### PR TITLE
Specify `--stack-yaml` in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ for Haskell to compile Aura yourself. Then:
 ```bash
 git clone https://github.com/fosskers/aura.git
 cd aura
-stack install -- aura
+stack --stack-yaml=haskell/stack.yaml install -- aura
 ```
 
 This may take a while to initially build all of Aura's dependencies. Once


### PR DESCRIPTION
Following the installation instructions from the README did not work for me because stack was not picking up the `stack.yaml` file in the `haskell` subdirectory. I needed to manually specify the location using the `--stack-yaml` argument.