### PR TITLE
filter `makepkg --packagelist` output for existing files

### DIFF
--- a/haskell/aura/lib/Aura/MakePkg.hs
+++ b/haskell/aura/lib/Aura/MakePkg.hs
@@ -69,7 +69,7 @@ make ss (User usr) pc = do
   (ec, se) <- runIt ss pc
   -- Fetch the filenames of the built tarballs.
   (_, out, _) <- readProcess $ proc "sudo" ["-u", T.unpack usr, makepkgCmd, "--packagelist"]
-  let fs = map T.unpack . T.lines . decodeUtf8Lenient $ BL.toStrict out
+  fs <- filterM doesFileExist . map T.unpack . T.lines . decodeUtf8Lenient $ BL.toStrict out
   pure (ec, se, fs)
 
 runIt :: MonadIO m

--- a/rust/aura-pm/src/command/aur/build.rs
+++ b/rust/aura-pm/src/command/aur/build.rs
@@ -362,6 +362,7 @@ fn tarball_paths(within: &Path) -> Result<Vec<PathBuf>, Error> {
         .map_err(Error::Utf8)?
         .lines()
         .map(|line| [line].iter().collect())
+        .filter(|path: &PathBuf| path.exists())
         .collect();
 
     Ok(tarballs)


### PR DESCRIPTION
The `makepkg --packagelist` command is intended to print which packages would be produced without building. This has a somewhat surprising interaction for packages that use `debug` and `strip`, which are now default: the `--packagelist` command will print a path to a debug tarball that may never be produced. There are more details on this behavior and why it is intended here: https://gitlab.archlinux.org/pacman/pacman/-/issues/141.

The recommended solution from the issue above is to filter the list for packages that exist on the filesystem. This patch does so for both aura 3 and 4. `aura -Ax dropbox-cli` will fail without the patch in both versions, e.g.:

    ==> Finished making: dropbox-cli 2024.04.17-2 (Sat 22 Jun 2024 11:28:34 AM EDT)
    loading packages...
    warning: dropbox-cli-2024.04.17-2 is up to date -- reinstalling
    error: '/var/cache/pacman/pkg/dropbox-cli-debug-2024.04.17-2-any.pkg.tar.zst': could not find or read package

and

    ==> Finished making: dropbox-cli 2024.04.17-2 (Sat 22 Jun 2024 11:17:14 AM EDT)
    mv: cannot stat '<snip>/dropbox-cli-debug-2024.04.17-2-any.pkg.tar.zst': No such file or directory
    aura :: Package failed to build, citing:

      Failed to move: <snip>/dropbox-cli-debug-2024.04.17-2-any.pkg.tar.zst

    aura :: Action cancelled.

With the patch, both versions of aura complete successfully.