### PR TITLE
fix(-A): detect more compression formats

### DIFF
--- a/rust/aura-core/src/cache.rs
+++ b/rust/aura-core/src/cache.rs
@@ -274,6 +274,7 @@ pub fn is_package(path: &Path) -> bool {
                 ".pkg.tar.Z",
                 ".pkg.tar.lz4",
                 ".pkg.tar.lz",
+                ".pkg.tar",
             ]
             .iter()
             .any(|ext| p.ends_with(ext))

--- a/rust/aura-core/src/cache.rs
+++ b/rust/aura-core/src/cache.rs
@@ -264,7 +264,19 @@ pub fn missing_tarballs<'a>(
 pub fn is_package(path: &Path) -> bool {
     path.to_str()
         .map(|p| {
-            p.ends_with(".pkg.tar.zst") || p.ends_with(".pkg.tar.xz") || p.ends_with(".pkg.tar")
+            [
+                ".pkg.tar.gz",
+                ".pkg.tar.bz2",
+                ".pkg.tar.xz",
+                ".pkg.tar.zst",
+                ".pkg.tar.lrz",
+                ".pkg.tar.lzo",
+                ".pkg.tar.Z",
+                ".pkg.tar.lz4",
+                ".pkg.tar.lz",
+            ]
+            .iter()
+            .any(|ext| p.ends_with(ext))
         })
         .unwrap_or(false)
 }


### PR DESCRIPTION
109ce6763e79e8a4123a6f9c5d7840ac2f536921 added support for uncompressed package tarballs, but the compression format was limited to xz or zstd. I added detection for all the compression formats mentioned in the default `makepkg.conf`:

```
COMPRESSGZ=(gzip -c -f -n)
COMPRESSBZ2=(bzip2 -c -f)
COMPRESSXZ=(xz -c -z -)
COMPRESSZST=(zstd -c -T0 -)
COMPRESSLRZ=(lrzip -q)
COMPRESSLZO=(lzop -q)
COMPRESSZ=(compress -c -f)
COMPRESSLZ4=(lz4 -q)
COMPRESSLZ=(lzip -c -f)
```

In particular this restores LZ4 support which broke for me when I recently upgraded to aura 4.0.